### PR TITLE
Use typed DispatchProperties setting

### DIFF
--- a/src/NServiceBus.TransactionalSession/TransactionalSessionDelayControlMessageBehavior.cs
+++ b/src/NServiceBus.TransactionalSession/TransactionalSessionDelayControlMessageBehavior.cs
@@ -1,7 +1,7 @@
 namespace NServiceBus.TransactionalSession
 {
     using System;
-    using System.Collections.Generic;
+    using DelayedDelivery;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -57,10 +57,10 @@ namespace NServiceBus.TransactionalSession
                     new Transport.TransportOperation(
                         new OutgoingMessage(messageId, context.MessageHeaders.ToDictionary(kvp => kvp.Key, kvp => kvp.Value), ReadOnlyMemory<byte>.Empty),
                         new UnicastAddressTag(physicalQueueAddress),
-                        new DispatchProperties(new Dictionary<string, string>
+                        new DispatchProperties
                         {
-                            {Headers.DeliverAt, DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow.Add(CommitDelayIncrement))},
-                        }),
+                            DelayDeliveryWith = new DelayDeliveryWith(CommitDelayIncrement)
+                        },
                         DispatchConsistency.Isolated
                     )
                 ), new TransportTransaction(), context.CancellationToken)


### PR DESCRIPTION
There is a special API to configure delayed delivery settings. The `Header.DeliverAt` value sets the wrong value and therefore the message is not delayed correctly.

Changing this from "delivery at" to "delay with" would probably also allow reusing the instance since the value can be reused.