### PR TITLE
share CaptureServiceProviderStartupTask across tests

### DIFF
--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/CaptureServiceProviderStartupTask.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/CaptureServiceProviderStartupTask.cs
@@ -1,0 +1,28 @@
+﻿namespace NServiceBus.TransactionalSession.AcceptanceTests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Features;
+
+    class CaptureServiceProviderStartupTask : FeatureStartupTask
+    {
+        public CaptureServiceProviderStartupTask(IServiceProvider serviceProvider, ScenarioContext context)
+        {
+            if (context is IInjectServiceProvider c)
+            {
+                c.ServiceProvider = serviceProvider;
+            }
+        }
+
+        protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    interface IInjectServiceProvider
+    {
+        IServiceProvider ServiceProvider { get; set; }
+    }
+}

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/TransactionSessionWithOutboxEndpoint.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/TransactionSessionWithOutboxEndpoint.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+    using AcceptanceTesting;
     using AcceptanceTesting.Support;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
 
@@ -12,8 +13,11 @@
             base.GetConfiguration(runDescriptor, endpointConfiguration, async configuration =>
             {
                 await configurationBuilderCustomization(configuration);
+
                 configuration.EnableTransactionalSession();
                 configuration.EnableOutbox();
+
+                configuration.RegisterStartupTask(provider => new CaptureServiceProviderStartupTask(provider, runDescriptor.ScenarioContext));
             });
     }
 }

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_not_using_outbox.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_not_using_outbox.cs
@@ -7,7 +7,6 @@
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using Features;
     using NUnit.Framework;
 
     public class When_not_using_outbox : NServiceBusAcceptanceTest
@@ -57,7 +56,7 @@
             Assert.False(result.MessageReceived);
         }
 
-        class Context : ScenarioContext
+        class Context : ScenarioContext, IInjectServiceProvider
         {
             public bool MessageReceived { get; set; }
             public bool CompleteMessageReceived { get; set; }
@@ -102,19 +101,6 @@
                 }
 
                 readonly Context testContext;
-            }
-
-            class CaptureServiceProviderStartupTask : FeatureStartupTask
-            {
-
-                public CaptureServiceProviderStartupTask(IServiceProvider serviceProvider, Context context)
-                {
-                    context.ServiceProvider = serviceProvider;
-                }
-
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
-
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_commits_after_control_message.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_commits_after_control_message.cs
@@ -1,14 +1,12 @@
 ﻿namespace NServiceBus.TransactionalSession.AcceptanceTests
 {
     using System;
-    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTesting.Customization;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.Features;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
 
@@ -50,7 +48,7 @@
 
         }
 
-        class Context : ScenarioContext
+        class Context : ScenarioContext, IInjectServiceProvider
         {
             public IServiceProvider ServiceProvider { get; set; }
             public bool MessageReceived { get; set; }
@@ -64,8 +62,6 @@
                 EndpointSetup<TransactionSessionWithOutboxEndpoint>((c, r) =>
                 {
                     c.Pipeline.Register(new UnblockCommitBehavior((Context)r.ScenarioContext), "unblocks the transactional session commit operation");
-                    c.RegisterStartupTask(provider =>
-                            new CaptureServiceProviderStartupTask(provider, (Context)r.ScenarioContext));
                     c.ConfigureRouting().RouteToEndpoint(typeof(SomeMessage), typeof(ReceiverEndpoint));
                 });
 
@@ -114,18 +110,6 @@
 
         class SomeMessage : IMessage
         {
-        }
-
-        class CaptureServiceProviderStartupTask : FeatureStartupTask
-        {
-            public CaptureServiceProviderStartupTask(IServiceProvider serviceProvider, Context context)
-            {
-                context.ServiceProvider = serviceProvider;
-            }
-
-            protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
-
-            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_commits_after_receiving_control_message.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_commits_after_receiving_control_message.cs
@@ -6,7 +6,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using Extensibility;
-    using Features;
     using Microsoft.Extensions.DependencyInjection;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -40,7 +39,7 @@
                 .Run(TimeSpan.FromSeconds(15));
         }
 
-        class Context : ScenarioContext
+        class Context : ScenarioContext, IInjectServiceProvider
         {
             public int MessageReceiveCounter = 0;
             public IServiceProvider ServiceProvider { get; set; }
@@ -55,8 +54,6 @@
                     c.ConfigureRouting().RouteToEndpoint(typeof(SomeMessage), typeof(ReceiverEndpoint));
 
                     c.Pipeline.Register(new DelayedOutboxTransactionCommitBehavior((Context)r.ScenarioContext), "delays the outbox transaction commit");
-
-                    c.RegisterStartupTask(sp => new CaptureServiceProviderStartupTask(sp, (Context)r.ScenarioContext));
                 });
 
 
@@ -80,15 +77,6 @@
                 }
 
                 readonly Context testContext;
-            }
-
-            class CaptureServiceProviderStartupTask : FeatureStartupTask
-            {
-                public CaptureServiceProviderStartupTask(IServiceProvider serviceProvider, Context context) => context.ServiceProvider = serviceProvider;
-
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
-
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_entry_becomes_visible_after_tx_timeout.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_entry_becomes_visible_after_tx_timeout.cs
@@ -49,7 +49,7 @@
 
         }
 
-        class Context : ScenarioContext
+        class Context : ScenarioContext, IInjectServiceProvider
         {
             public IServiceProvider ServiceProvider { get; set; }
             public bool MessageReceived { get; set; }
@@ -63,7 +63,6 @@
                 {
                     c.ConfigureRouting().RouteToEndpoint(typeof(SomeMessage), typeof(ReceiverEndpoint));
                     c.Pipeline.Register(new StorageManipulationBehavior(), "configures the outbox to not see the commited values yet");
-                    c.RegisterStartupTask(sp => new CaptureServiceProviderStartupTask(sp, (Context)r.ScenarioContext));
                 });
 
             class StorageManipulationBehavior : Behavior<ITransportReceiveContext>
@@ -74,15 +73,6 @@
 
                     return next();
                 }
-            }
-
-            class CaptureServiceProviderStartupTask : FeatureStartupTask
-            {
-                public CaptureServiceProviderStartupTask(IServiceProvider serviceProvider, Context context) => context.ServiceProvider = serviceProvider;
-
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
-
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
             }
         }
 


### PR DESCRIPTION
Reuses the `CaptureServiceProviderStartupTask` instead of having to define it in every test.

The shared behavior looks for a specific interface to inject the `IServiceProvider` instance and is registered by default in the `TransactionSessionWithOutboxEndpoint` endpoint template.