### PR TITLE
Add session disposed/committed state checks

### DIFF
--- a/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
@@ -92,7 +92,7 @@ public class OutboxTransactionalSessionTests
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await session.Send(new object()));
 
-        StringAssert.Contains("The session has to be opened before sending any messages", exception.Message);
+        StringAssert.Contains("This session has not been opened yet.", exception.Message);
         Assert.IsEmpty(messageSession.SentMessages);
     }
 
@@ -104,7 +104,7 @@ public class OutboxTransactionalSessionTests
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await session.Publish(new object()));
 
-        StringAssert.Contains("The session has to be opened before publishing any messages", exception.Message);
+        StringAssert.Contains("This session has not been opened yet.", exception.Message);
         Assert.IsEmpty(messageSession.PublishedMessages);
     }
 
@@ -202,18 +202,6 @@ public class OutboxTransactionalSessionTests
         Assert.AreEqual(expectedMaximumCommitDuration.ToString("c"), controlMessage.Message.Headers[OutboxTransactionalSession.RemainingCommitDurationHeaderName]);
         Assert.AreEqual(expectedMetadataValue, controlMessage.Message.Headers["metadata-key"], "metadata should be propagated to headers");
         Assert.IsFalse(controlMessage.Message.Headers.ContainsKey("extensions-key"), "extensions should not be propagated to headers");
-    }
-
-    [Test]
-    public async Task Open_should_throw_if_session_already_open()
-    {
-        using ITransactionalSession session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), new FakeMessageSession(), new FakeDispatcher(), "queue address");
-
-        await session.Open();
-
-        var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await session.Open());
-
-        StringAssert.Contains("This session is already open. Open should only be called once.", exception.Message);
     }
 
     [Test]

--- a/src/NServiceBus.TransactionalSession.Tests/TransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/TransactionalSessionTests.cs
@@ -81,7 +81,7 @@ public class TransactionalSessionTests
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await session.Send(new object()));
 
-        StringAssert.Contains("The session has to be opened before sending any messages.", exception.Message);
+        StringAssert.Contains("This session has not been opened yet.", exception.Message);
         Assert.IsEmpty(messageSession.SentMessages);
     }
 
@@ -93,7 +93,7 @@ public class TransactionalSessionTests
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await session.Publish(new object()));
 
-        StringAssert.Contains("The session has to be opened before publishing any messages.", exception.Message);
+        StringAssert.Contains("This session has not been opened yet.", exception.Message);
         Assert.IsEmpty(messageSession.PublishedMessages);
     }
 

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -26,6 +26,10 @@
 
         public override async Task Commit(CancellationToken cancellationToken = default)
         {
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
+
             var headers = new Dictionary<string, string>
             {
                 { Headers.MessageId, SessionId },
@@ -53,9 +57,52 @@
             await synchronizedStorageSession.CompleteAsync(cancellationToken).ConfigureAwait(false);
 
             await outboxTransaction.Commit(cancellationToken).ConfigureAwait(false);
+
+            committed = true;
         }
 
-        protected override void Dispose(bool disposing)
+        public async Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
+
+            sendOptions.GetExtensions().Set(pendingOperations);
+            await messageSession.Send(message, sendOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
+
+            sendOptions.GetExtensions().Set(pendingOperations);
+            await messageSession.Send(messageConstructor, sendOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task Publish(object message, PublishOptions publishOptions, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
+
+            publishOptions.GetExtensions().Set(pendingOperations);
+            await messageSession.Publish(message, publishOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
+
+            publishOptions.GetExtensions().Set(pendingOperations);
+            await messageSession.Publish(messageConstructor, publishOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        public void Dispose()
         {
             if (disposed)
             {
@@ -105,6 +152,15 @@
         public override async Task Open(OpenSessionOptions options = null, CancellationToken cancellationToken = default)
         {
             await base.Open(options, cancellationToken).ConfigureAwait(false);
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+
+            if (IsOpen)
+            {
+                throw new InvalidOperationException($"This session is already open. Open should only be called once.");
+            }
+
+            this.options = options ?? new OpenSessionOptions();
 
             outboxTransaction = await outboxStorage.BeginTransaction(Context, cancellationToken).ConfigureAwait(false);
 
@@ -113,6 +169,38 @@
                 throw new Exception("Outbox and synchronized storage persister are not compatible.");
             }
         }
+
+        void ThrowIfDisposed()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(Dispose));
+            }
+        }
+
+        void ThrowIfCommitted()
+        {
+            if (committed)
+            {
+                throw new InvalidOperationException("This session has already been committed. Complete all session operations before calling `Commit` or use a new session.");
+            }
+        }
+
+        void ThrowIfNotOpened()
+        {
+            if (!IsOpen)
+            {
+                throw new InvalidOperationException("This session has not been opened yet. Make sure to open the session first by calling the `Open`-method.");
+            }
+        }
+
+        bool committed;
+
+        bool disposed;
+
+        IOutboxTransaction outboxTransaction;
+
+        OpenSessionOptions options;
 
         readonly string physicalQueueAddress;
         readonly IOutboxStorage outboxStorage;

--- a/src/NServiceBus.TransactionalSession/TransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/TransactionalSession.cs
@@ -14,7 +14,7 @@
         {
         }
 
-        public override async Task Commit(CancellationToken cancellationToken = default)
+        protected override async Task CommitInternal(CancellationToken cancellationToken = default)
         {
             await synchronizedStorageSession.CompleteAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/NServiceBus.TransactionalSession/TransactionalSessionBase.cs
+++ b/src/NServiceBus.TransactionalSession/TransactionalSessionBase.cs
@@ -54,14 +54,14 @@ namespace NServiceBus.TransactionalSession
 
         public async Task Commit(CancellationToken cancellationToken = default)
         {
-            ThrowIfDisposed();
-            ThrowIfCommitted();
-            ThrowIfNotOpened();
+            ThrowIfInvalidState();
 
             await CommitInternal(cancellationToken).ConfigureAwait(false);
 
             committed = true;
         }
+
+
         protected abstract Task CommitInternal(CancellationToken cancellationToken = default);
 
         public virtual Task Open(OpenSessionOptions options = null, CancellationToken cancellationToken = default)
@@ -82,9 +82,7 @@ namespace NServiceBus.TransactionalSession
 
         public async Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
         {
-            ThrowIfDisposed();
-            ThrowIfCommitted();
-            ThrowIfNotOpened();
+            ThrowIfInvalidState();
 
             sendOptions.GetExtensions().Set(pendingOperations);
             await messageSession.Send(message, sendOptions, cancellationToken).ConfigureAwait(false);
@@ -92,9 +90,7 @@ namespace NServiceBus.TransactionalSession
 
         public async Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions, CancellationToken cancellationToken = default)
         {
-            ThrowIfDisposed();
-            ThrowIfCommitted();
-            ThrowIfNotOpened();
+            ThrowIfInvalidState();
 
             sendOptions.GetExtensions().Set(pendingOperations);
             await messageSession.Send(messageConstructor, sendOptions, cancellationToken).ConfigureAwait(false);
@@ -102,9 +98,7 @@ namespace NServiceBus.TransactionalSession
 
         public async Task Publish(object message, PublishOptions publishOptions, CancellationToken cancellationToken = default)
         {
-            ThrowIfDisposed();
-            ThrowIfCommitted();
-            ThrowIfNotOpened();
+            ThrowIfInvalidState();
 
             publishOptions.GetExtensions().Set(pendingOperations);
             await messageSession.Publish(message, publishOptions, cancellationToken).ConfigureAwait(false);
@@ -112,9 +106,7 @@ namespace NServiceBus.TransactionalSession
 
         public async Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions, CancellationToken cancellationToken = default)
         {
-            ThrowIfDisposed();
-            ThrowIfCommitted();
-            ThrowIfNotOpened();
+            ThrowIfInvalidState();
 
             publishOptions.GetExtensions().Set(pendingOperations);
             await messageSession.Publish(messageConstructor, publishOptions, cancellationToken).ConfigureAwait(false);
@@ -142,6 +134,13 @@ namespace NServiceBus.TransactionalSession
             {
                 throw new InvalidOperationException("This session has not been opened yet.");
             }
+        }
+
+        void ThrowIfInvalidState()
+        {
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
         }
 
         public void Dispose()

--- a/src/NServiceBus.TransactionalSession/TransactionalSessionBase.cs
+++ b/src/NServiceBus.TransactionalSession/TransactionalSessionBase.cs
@@ -52,10 +52,23 @@ namespace NServiceBus.TransactionalSession
 
         protected bool IsOpen => options != null;
 
-        public abstract Task Commit(CancellationToken cancellationToken = default);
+        public async Task Commit(CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
+
+            await CommitInternal(cancellationToken).ConfigureAwait(false);
+
+            committed = true;
+        }
+        protected abstract Task CommitInternal(CancellationToken cancellationToken = default);
 
         public virtual Task Open(OpenSessionOptions options = null, CancellationToken cancellationToken = default)
         {
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+
             if (IsOpen)
             {
                 throw new InvalidOperationException($"This session is already open. {nameof(ITransactionalSession)}.{nameof(ITransactionalSession.Open)} should only be called once.");
@@ -69,10 +82,9 @@ namespace NServiceBus.TransactionalSession
 
         public async Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
         {
-            if (!IsOpen)
-            {
-                throw new InvalidOperationException("The session has to be opened before sending any messages.");
-            }
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
 
             sendOptions.GetExtensions().Set(pendingOperations);
             await messageSession.Send(message, sendOptions, cancellationToken).ConfigureAwait(false);
@@ -80,10 +92,9 @@ namespace NServiceBus.TransactionalSession
 
         public async Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions, CancellationToken cancellationToken = default)
         {
-            if (!IsOpen)
-            {
-                throw new InvalidOperationException("The session has to be opened before sending any messages.");
-            }
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
 
             sendOptions.GetExtensions().Set(pendingOperations);
             await messageSession.Send(messageConstructor, sendOptions, cancellationToken).ConfigureAwait(false);
@@ -91,10 +102,9 @@ namespace NServiceBus.TransactionalSession
 
         public async Task Publish(object message, PublishOptions publishOptions, CancellationToken cancellationToken = default)
         {
-            if (!IsOpen)
-            {
-                throw new InvalidOperationException("The session has to be opened before publishing any messages.");
-            }
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
 
             publishOptions.GetExtensions().Set(pendingOperations);
             await messageSession.Publish(message, publishOptions, cancellationToken).ConfigureAwait(false);
@@ -102,13 +112,36 @@ namespace NServiceBus.TransactionalSession
 
         public async Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions, CancellationToken cancellationToken = default)
         {
-            if (!IsOpen)
-            {
-                throw new InvalidOperationException("The session has to be opened before publishing any messages.");
-            }
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+            ThrowIfNotOpened();
 
             publishOptions.GetExtensions().Set(pendingOperations);
             await messageSession.Publish(messageConstructor, publishOptions, cancellationToken).ConfigureAwait(false);
+        }
+
+        void ThrowIfDisposed()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(Dispose));
+            }
+        }
+
+        void ThrowIfCommitted()
+        {
+            if (committed)
+            {
+                throw new InvalidOperationException("This session has already been committed. Complete all session operations before calling `Commit` or use a new session.");
+            }
+        }
+
+        void ThrowIfNotOpened()
+        {
+            if (!IsOpen)
+            {
+                throw new InvalidOperationException("This session has not been opened yet.");
+            }
         }
 
         public void Dispose()
@@ -140,5 +173,6 @@ namespace NServiceBus.TransactionalSession
         protected OpenSessionOptions options;
         readonly IMessageSession messageSession;
         protected bool disposed;
+        protected bool committed;
     }
 }


### PR DESCRIPTION
Adds checks to the sessions to prevent usage of the operations in an invalid session state.
* The `ITransactionalSession` must be opened before any other operation (including `Commit`)
* Both sessions should throw when the session has been disposed to prevent incorrect usage of the session after it has been disposed (by the DI container) but remains around due to incorrect caching of the session.
* Both sessions should also throw when they have already been committed before another operation has been called
* Dispose should always be valid to be called. It's easy to have double-disposal in case the user uses a `using` statement with the session that is resolved from the DI container within a method since the DI container will also dispose instances created in the unit-of-work scope.

Note that access to the storage property currently does not throw. It is expected that the storage session instance handles incorrect usage after disposal already. Maybe it should throw after commit though?