### PR TITLE
Add additional test cases to test session access via DI

### DIFF
--- a/src/NServiceBus.TransactionalSession.AcceptanceTests.AzureTable/When_using_transactional_session.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests.AzureTable/When_using_transactional_session.cs
@@ -64,7 +64,7 @@
 
         [TestCase(true)]
         [TestCase(false)]
-        public async Task Should_send_messages_and_store_document_in_sql_session_on_transactional_session_commit(bool outboxEnabled)
+        public async Task Should_send_messages_and_store_document_in_azuretable_session_on_transactional_session_commit(bool outboxEnabled)
         {
             var entityRowId = Guid.NewGuid().ToString();
 

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests.CosmosDB/When_using_transactional_session.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests.CosmosDB/When_using_transactional_session.cs
@@ -18,7 +18,7 @@
 
         [TestCase(true)]
         [TestCase(false)]
-        public async Task Should_send_messages_and_store_document_on_transactional_session_commit(bool outboxEnabled)
+        public async Task Should_send_messages_and_store_document_in_synchronized_session_on_transactional_session_commit(bool outboxEnabled)
         {
             var documentId = Guid.NewGuid().ToString();
 
@@ -36,6 +36,44 @@
                     await transactionalSession.Send(new SampleMessage(), sendOptions, CancellationToken.None);
 
                     var storageSession = transactionalSession.SynchronizedStorageSession.CosmosPersistenceSession();
+                    storageSession.Batch.CreateItem(new MyDocument
+                    {
+                        Id = documentId,
+                        Data = "SomeData",
+                        PartitionKey = PartitionKeyValue
+                    });
+
+                    await transactionalSession.Commit(CancellationToken.None).ConfigureAwait(false);
+                }))
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            var response = await CosmosSetup.Container.ReadItemAsync<MyDocument>(documentId, new PartitionKey(PartitionKeyValue));
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual("SomeData", response.Resource.Data);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task Should_send_messages_and_store_document_in_cosmos_session_on_transactional_session_commit(bool outboxEnabled)
+        {
+            var documentId = Guid.NewGuid().ToString();
+
+            await Scenario.Define<Context>()
+                .WithEndpoint<AnEndpoint>(s => s.When(async (_, ctx) =>
+                {
+                    using var scope = ctx.ServiceProvider.CreateScope();
+                    using var transactionalSession = scope.ServiceProvider.GetRequiredService<ITransactionalSession>();
+                    await transactionalSession.OpenCosmosDBSession(PartitionKeyValue);
+
+                    var sendOptions = new SendOptions();
+                    sendOptions.SetHeader(PartitionKeyHeaderName, PartitionKeyValue);
+                    sendOptions.RouteToThisEndpoint();
+
+                    await transactionalSession.Send(new SampleMessage(), sendOptions, CancellationToken.None);
+
+                    var storageSession = scope.ServiceProvider.GetRequiredService<ICosmosStorageSession>();
                     storageSession.Batch.CreateItem(new MyDocument
                     {
                         Id = documentId,

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests.SqlP/When_using_transactional_session.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests.SqlP/When_using_transactional_session.cs
@@ -17,7 +17,7 @@
 
         [TestCase(true)]
         [TestCase(false)]
-        public async Task Should_send_messages_and_insert_rows_in_sychronized_session_on_transactional_session_commit(bool outboxEnabled)
+        public async Task Should_send_messages_and_insert_rows_in_synchronized_session_on_transactional_session_commit(bool outboxEnabled)
         {
             var rowId = Guid.NewGuid().ToString();
 


### PR DESCRIPTION
Adds acceptance tests that test access to the storage specific session via DI instead of the extension methods on the `transactionalSession.SynchronizedStorageSession` property as this is supposed to be supported.