### PR TITLE
Spike: Dispatch operations immediately after the storage transaction completes

### DIFF
--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_entry_becomes_visible_after_tx_timeout.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_entry_becomes_visible_after_tx_timeout.cs
@@ -12,7 +12,7 @@
 
     public class When_outbox_entry_becomes_visible_after_tx_timeout : NServiceBusAcceptanceTest
     {
-        [Test]
+        [Test, Ignore("No longer applicable if outbox is dispatch immediately")]
         public async Task Should_fail_to_process_control_message()
         {
             var context = await Scenario.Define<Context>()

--- a/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
@@ -126,8 +126,8 @@
             await session.Send(new object(), sendOptions);
             await session.Commit();
 
-            Assert.AreEqual(1, dispatcher.Dispatched.Count, "should have dispatched control message");
-            var dispatched = dispatcher.Dispatched.Single();
+            Assert.AreEqual(2, dispatcher.Dispatched.Count, "should have dispatched control message + outbox message");
+            var dispatched = dispatcher.Dispatched.First();
             Assert.AreEqual(1, dispatched.outgoingMessages.UnicastTransportOperations.Count);
             var controlMessage = dispatched.outgoingMessages.UnicastTransportOperations.Single();
             Assert.AreEqual(session.SessionId, controlMessage.Message.MessageId);
@@ -195,7 +195,7 @@
             await session.Open(options);
             await session.Commit();
 
-            var controlMessage = dispatcher.Dispatched.Single().outgoingMessages.UnicastTransportOperations.Single();
+            var controlMessage = dispatcher.Dispatched.First().outgoingMessages.UnicastTransportOperations.Single();
             Assert.AreEqual(session.SessionId, controlMessage.Message.MessageId);
             Assert.AreEqual(bool.TrueString, controlMessage.Message.Headers[Headers.ControlMessageHeader]);
             Assert.AreEqual(expectedDelayIncrement.ToString("c"), controlMessage.Message.Headers[OutboxTransactionalSession.CommitDelayIncrementHeaderName]);

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -44,7 +44,13 @@
             }
             var message = new OutgoingMessage(SessionId, headers, ReadOnlyMemory<byte>.Empty);
 
-            var outgoingMessages = new TransportOperations(new TransportTransportOperation(message, new UnicastAddressTag(physicalQueueAddress), new DispatchProperties { DelayDeliveryWith = new DelayDeliveryWith(TimeSpan.FromMinutes(1)) }));
+            var transportMessage = new TransportTransportOperation(
+                message,
+                new UnicastAddressTag(physicalQueueAddress),
+                new DispatchProperties { DelayDeliveryWith = new DelayDeliveryWith(controlMessageDeliveryDelay) }
+                );
+
+            var outgoingMessages = new TransportOperations(transportMessage);
             await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(), cancellationToken).ConfigureAwait(false);
 
             var outboxMessage =
@@ -127,6 +133,7 @@
 
         readonly string physicalQueueAddress;
         readonly IOutboxStorage outboxStorage;
+        readonly TimeSpan controlMessageDeliveryDelay = TimeSpan.FromSeconds(3);
         IOutboxTransaction outboxTransaction;
         public const string RemainingCommitDurationHeaderName = "NServiceBus.TransactionalSession.RemainingCommitDuration";
         public const string CommitDelayIncrementHeaderName = "NServiceBus.TransactionalSession.CommitDelayIncrement";


### PR DESCRIPTION
- Resolves https://github.com/Particular/NServiceBus.TransactionalSession/issues/145

1. Dispatch operations immediately after the storage transaction completes
2. Delays the control message that fakes a message that will act as a backup in case a failure occurs during dispatch.