### PR TITLE
Transaction.Current may not be set after opening the session

### DIFF
--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_outbox.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_outbox.cs
@@ -2,6 +2,7 @@
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Transactions;
     using AcceptanceTesting;
     using Infrastructure;
     using NUnit.Framework;
@@ -74,10 +75,39 @@
             Assert.True(result.MessageReceived);
         }
 
+        [Test]
+        public async Task Should_make_it_possible_float_ambient_transactions()
+        {
+            var result = await Scenario.Define<Context>()
+                    .WithEndpoint<AnEndpoint>(s => s.When(async (_, ctx) =>
+                    {
+                        using var scope = ctx.Builder.CreateChildBuilder();
+                        using var transactionalSession = scope.Build<ITransactionalSession>();
+
+                        await transactionalSession.Open(new CustomTestingPersistenceOpenSessionOptions
+                        {
+                            UseTransactionScope = true
+                        });
+
+                        ctx.AmbientTransactionFoundBeforeAwait = Transaction.Current != null;
+
+                        await Task.Yield();
+
+                        ctx.AmbientTransactionFoundAfterAwait = Transaction.Current != null;
+                    }))
+                    .Done(c => c.EndpointsStarted)
+                    .Run();
+
+            Assert.True(result.AmbientTransactionFoundBeforeAwait, "The ambient transaction was not visible before the await");
+            Assert.True(result.AmbientTransactionFoundAfterAwait, "The ambient transaction was not visible after the await");
+        }
+
         class Context : ScenarioContext, IInjectBuilder
         {
-            public bool MessageReceived { get; set; }
+            public bool AmbientTransactionFoundBeforeAwait { get; set; }
+            public bool AmbientTransactionFoundAfterAwait { get; set; }
             public bool CompleteMessageReceived { get; set; }
+            public bool MessageReceived { get; set; }
             public IBuilder Builder { get; set; }
         }
 

--- a/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingOutboxStorage.cs
+++ b/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingOutboxStorage.cs
@@ -3,8 +3,10 @@ namespace NServiceBus.AcceptanceTesting
     using System;
     using System.Collections.Concurrent;
     using System.Threading.Tasks;
+    using System.Transactions;
     using Extensibility;
     using Outbox;
+    using TransactionalSession;
 
     sealed class CustomTestingOutboxStorage : IOutboxStorage
     {
@@ -25,6 +27,11 @@ namespace NServiceBus.AcceptanceTesting
 
         public Task<OutboxTransaction> BeginTransaction(ContextBag context)
         {
+            if (context.TryGet(out CustomTestingPersistenceOpenSessionOptions options) && options.UseTransactionScope)
+            {
+                _ = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled);
+            }
+
             return Task.FromResult<OutboxTransaction>(new CustomTestingOutboxTransaction(context));
         }
 

--- a/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingPersistenceOpenSessionOptions.cs
+++ b/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingPersistenceOpenSessionOptions.cs
@@ -7,5 +7,7 @@ namespace NServiceBus.TransactionalSession
         public CustomTestingPersistenceOpenSessionOptions() => Extensions.Set(this);
 
         public TaskCompletionSource<bool> TransactionCommitTaskCompletionSource { get; set; }
+
+        public bool UseTransactionScope { get; set; }
     }
 }

--- a/src/NServiceBus.TransactionalSession/NonOutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/NonOutboxTransactionalSession.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.TransactionalSession
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -26,7 +27,20 @@
 
         public override async Task Open(OpenSessionOptions options, CancellationToken cancellationToken = default)
         {
-            await base.Open(options, cancellationToken).ConfigureAwait(false);
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+
+            if (IsOpen)
+            {
+                throw new InvalidOperationException($"This session is already open. {nameof(ITransactionalSession)}.{nameof(ITransactionalSession.Open)} should only be called once.");
+            }
+
+            this.options = options;
+
+            foreach (var customization in customizations)
+            {
+                customization.Apply(this.options);
+            }
 
             await synchronizedStorageSession.Open(null, new TransportTransaction(), Context).ConfigureAwait(false);
         }

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -141,11 +141,32 @@
             throw new Exception($"Unknown delivery constraint {constraint.GetType().FullName}");
         }
 
-        public override async Task Open(OpenSessionOptions options, CancellationToken cancellationToken = default)
+        public override Task Open(OpenSessionOptions options, CancellationToken cancellationToken = default)
         {
-            await base.Open(options, cancellationToken).ConfigureAwait(false);
+            ThrowIfDisposed();
+            ThrowIfCommitted();
 
-            outboxTransaction = await outboxStorage.BeginTransaction(Context).ConfigureAwait(false);
+            if (IsOpen)
+            {
+                throw new InvalidOperationException($"This session is already open. {nameof(ITransactionalSession)}.{nameof(ITransactionalSession.Open)} should only be called once.");
+            }
+
+            this.options = options;
+
+            foreach (var customization in customizations)
+            {
+                customization.Apply(this.options);
+            }
+
+            // Unfortunately this is the only way to make it possible for Transaction.Current to float up to the caller
+            // to make sure SQLP and NHibernate work with the transaction scope
+            var outboxTransactionTask = outboxStorage.BeginTransaction(Context);
+            return OpenInternal(outboxTransactionTask, cancellationToken);
+        }
+
+        async Task OpenInternal(Task<OutboxTransaction> beginTransactionTask, CancellationToken cancellationToken)
+        {
+            outboxTransaction = await beginTransactionTask.ConfigureAwait(false);
 
             if (!await synchronizedStorageSession.TryOpen(outboxTransaction, Context).ConfigureAwait(false))
             {

--- a/src/NServiceBus.TransactionalSession/TransactionalSessionBase.cs
+++ b/src/NServiceBus.TransactionalSession/TransactionalSessionBase.cs
@@ -64,28 +64,9 @@ namespace NServiceBus.TransactionalSession
             committed = true;
         }
 
+        public abstract Task Open(OpenSessionOptions options, CancellationToken cancellationToken = default);
 
         protected abstract Task CommitInternal(CancellationToken cancellationToken = default);
-
-        public virtual Task Open(OpenSessionOptions options, CancellationToken cancellationToken = default)
-        {
-            ThrowIfDisposed();
-            ThrowIfCommitted();
-
-            if (IsOpen)
-            {
-                throw new InvalidOperationException($"This session is already open. {nameof(ITransactionalSession)}.{nameof(ITransactionalSession.Open)} should only be called once.");
-            }
-
-            this.options = options;
-
-            foreach (var customization in customizations)
-            {
-                customization.Apply(this.options);
-            }
-
-            return Task.CompletedTask;
-        }
 
         public async Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
         {
@@ -119,7 +100,7 @@ namespace NServiceBus.TransactionalSession
             await messageSession.Publish(messageConstructor, publishOptions).ConfigureAwait(false);
         }
 
-        void ThrowIfDisposed()
+        protected void ThrowIfDisposed()
         {
             if (disposed)
             {
@@ -127,7 +108,7 @@ namespace NServiceBus.TransactionalSession
             }
         }
 
-        void ThrowIfCommitted()
+        protected void ThrowIfCommitted()
         {
             if (committed)
             {
@@ -170,7 +151,7 @@ namespace NServiceBus.TransactionalSession
 
         protected readonly CompletableSynchronizedStorageSessionAdapter synchronizedStorageSession;
         protected readonly IDispatchMessages dispatcher;
-        readonly IEnumerable<IOpenSessionOptionsCustomization> customizations;
+        protected readonly IEnumerable<IOpenSessionOptionsCustomization> customizations;
         protected readonly PendingTransportOperations pendingOperations;
         protected OpenSessionOptions options;
         readonly IMessageSession messageSession;


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.TransactionalSession/pull/184 to `release-1.0`