### PR TITLE
Transaction.Current may not be set after opening the session

### DIFF
--- a/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingOutboxStorage.cs
+++ b/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingOutboxStorage.cs
@@ -4,8 +4,10 @@ namespace NServiceBus.AcceptanceTesting
     using System.Collections.Concurrent;
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Transactions;
     using Extensibility;
     using Outbox;
+    using TransactionalSession;
 
     sealed class CustomTestingOutboxStorage : IOutboxStorage
     {
@@ -26,6 +28,11 @@ namespace NServiceBus.AcceptanceTesting
 
         public Task<IOutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default)
         {
+            if (context.TryGet(out CustomTestingPersistenceOpenSessionOptions options) && options.UseTransactionScope)
+            {
+                _ = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled);
+            }
+
             return Task.FromResult<IOutboxTransaction>(new CustomTestingOutboxTransaction(context));
         }
 

--- a/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingPersistenceOpenSessionOptions.cs
+++ b/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingPersistenceOpenSessionOptions.cs
@@ -7,5 +7,7 @@
         public CustomTestingPersistenceOpenSessionOptions() => Extensions.Set(this);
 
         public TaskCompletionSource<bool> TransactionCommitTaskCompletionSource { get; set; }
+
+        public bool UseTransactionScope { get; set; }
     }
 }

--- a/src/NServiceBus.TransactionalSession/NonOutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/NonOutboxTransactionalSession.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.TransactionalSession
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -25,7 +26,20 @@
 
         public override async Task Open(OpenSessionOptions options, CancellationToken cancellationToken = default)
         {
-            await base.Open(options, cancellationToken).ConfigureAwait(false);
+            ThrowIfDisposed();
+            ThrowIfCommitted();
+
+            if (IsOpen)
+            {
+                throw new InvalidOperationException($"This session is already open. {nameof(ITransactionalSession)}.{nameof(ITransactionalSession.Open)} should only be called once.");
+            }
+
+            this.options = options;
+
+            foreach (var customization in customizations)
+            {
+                customization.Apply(this.options);
+            }
 
             await synchronizedStorageSession.Open(null, new TransportTransaction(), Context, cancellationToken).ConfigureAwait(false);
         }

--- a/src/NServiceBus.TransactionalSession/TransactionalSessionBase.cs
+++ b/src/NServiceBus.TransactionalSession/TransactionalSessionBase.cs
@@ -64,28 +64,9 @@ namespace NServiceBus.TransactionalSession
             committed = true;
         }
 
+        public abstract Task Open(OpenSessionOptions options, CancellationToken cancellationToken = default);
 
         protected abstract Task CommitInternal(CancellationToken cancellationToken = default);
-
-        public virtual Task Open(OpenSessionOptions options, CancellationToken cancellationToken = default)
-        {
-            ThrowIfDisposed();
-            ThrowIfCommitted();
-
-            if (IsOpen)
-            {
-                throw new InvalidOperationException($"This session is already open. {nameof(ITransactionalSession)}.{nameof(ITransactionalSession.Open)} should only be called once.");
-            }
-
-            this.options = options;
-
-            foreach (var customization in customizations)
-            {
-                customization.Apply(this.options);
-            }
-
-            return Task.CompletedTask;
-        }
 
         public async Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
         {
@@ -119,7 +100,7 @@ namespace NServiceBus.TransactionalSession
             await messageSession.Publish(messageConstructor, publishOptions, cancellationToken).ConfigureAwait(false);
         }
 
-        void ThrowIfDisposed()
+        protected void ThrowIfDisposed()
         {
             if (disposed)
             {
@@ -127,7 +108,7 @@ namespace NServiceBus.TransactionalSession
             }
         }
 
-        void ThrowIfCommitted()
+        protected void ThrowIfCommitted()
         {
             if (committed)
             {
@@ -170,7 +151,7 @@ namespace NServiceBus.TransactionalSession
 
         protected readonly ICompletableSynchronizedStorageSession synchronizedStorageSession;
         protected readonly IMessageDispatcher dispatcher;
-        readonly IEnumerable<IOpenSessionOptionsCustomization> customizations;
+        protected readonly IEnumerable<IOpenSessionOptionsCustomization> customizations;
         protected readonly PendingTransportOperations pendingOperations;
         protected OpenSessionOptions options;
         readonly IMessageSession messageSession;


### PR DESCRIPTION
Backport of https://github.com/Particular/NServiceBus.TransactionalSession/pull/184 to `release-2.0