### PR TITLE
Complete synchronized storage session before storing outbox data

### DIFF
--- a/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
@@ -169,7 +169,7 @@
             Assert.AreEqual(bool.TrueString, controlMessage.Message.Headers[Headers.ControlMessageHeader]);
 
             var outboxTransaction = outboxStorage.StartedTransactions.Single();
-            Assert.IsFalse(outboxTransaction.Commited, "should not have commited outbox operations");
+            Assert.IsFalse(outboxTransaction.Commited, "should not have committed outbox operations");
         }
 
         [Test]
@@ -187,7 +187,7 @@
 
             var outboxTransaction = outboxStorage.StartedTransactions.Single();
             Assert.IsTrue(completableSynchronizedStorageSession.Completed, "should have completed synchronized storage session to match the receive pipeline behavior");
-            Assert.IsFalse(outboxTransaction.Commited, "should not have commited outbox operations");
+            Assert.IsFalse(outboxTransaction.Commited, "should not have committed outbox operations");
         }
 
         [Test]

--- a/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
@@ -169,7 +169,24 @@
             Assert.AreEqual(bool.TrueString, controlMessage.Message.Headers[Headers.ControlMessageHeader]);
 
             var outboxTransaction = outboxStorage.StartedTransactions.Single();
-            Assert.IsFalse(completableSynchronizedStorageSession.Completed, "should not have completed synchronized storage session");
+            Assert.IsFalse(outboxTransaction.Commited, "should not have commited outbox operations");
+        }
+
+        [Test]
+        public async Task Commit_should_complete_synchronized_storage_session_before_outbox_store()
+        {
+            var messageSession = new FakeMessageSession();
+            var dispatcher = new FakeDispatcher();
+            var outboxStorage = new FakeOutboxStorage { StoreCallback = (_, _, _) => throw new Exception("some error") };
+            var completableSynchronizedStorageSession = new FakeSynchronizableStorageSession();
+            using var session = new OutboxTransactionalSession(outboxStorage, completableSynchronizedStorageSession, messageSession, dispatcher, Enumerable.Empty<IOpenSessionOptionsCustomization>(), "queue address");
+
+            await session.Open(new FakeOpenSessionOptions());
+            await session.Send(new object());
+            Assert.ThrowsAsync<Exception>(async () => await session.Commit());
+
+            var outboxTransaction = outboxStorage.StartedTransactions.Single();
+            Assert.IsTrue(completableSynchronizedStorageSession.Completed, "should have completed synchronized storage session to match the receive pipeline behavior");
             Assert.IsFalse(outboxTransaction.Commited, "should not have commited outbox operations");
         }
 

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -45,12 +45,12 @@
             var outgoingMessages = new TransportOperations(new TransportTransportOperation(message, new UnicastAddressTag(physicalQueueAddress)));
             await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(), cancellationToken).ConfigureAwait(false);
 
+            await synchronizedStorageSession.CompleteAsync(cancellationToken).ConfigureAwait(false);
+
             var outboxMessage =
                 new OutboxMessage(SessionId, ConvertToOutboxOperations(pendingOperations.Operations));
             await outboxStorage.Store(outboxMessage, outboxTransaction, Context, cancellationToken)
                 .ConfigureAwait(false);
-
-            await synchronizedStorageSession.CompleteAsync(cancellationToken).ConfigureAwait(false);
 
             await outboxTransaction.Commit(cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
This is more aligned with Core's behavior in the incoming pipeline, where the session is completed in the [LoadHandlersConnector](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs#L49) while the outbox `Store` operations happens in the [TransportReceiveToPhysicalMessageConnector](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs#L38) afterwards.