### PR TITLE
Complete synchronized storage session before storing outbox data 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           fail-fast: false
       steps:
       - name: Checkout
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
       - name: Setup .NET SDK
@@ -34,11 +34,11 @@ jobs:
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages
-        if: matrix.upload-packages && runner.os == 'Windows'
-        uses: actions/upload-artifact@v3.1.1
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: NuGet packages
           path: nugets/
           retention-days: 7
       - name: Run tests
-        uses: Particular/run-tests-action@v1.4.0
+        uses: Particular/run-tests-action@v1.5.1

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/NServiceBus.TransactionalSession.AcceptanceTests.csproj
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/NServiceBus.TransactionalSession.AcceptanceTests.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="7.8.0" />
   </ItemGroup>
 

--- a/src/NServiceBus.TransactionalSession.Tests/NServiceBus.TransactionalSession.Tests.csproj
+++ b/src/NServiceBus.TransactionalSession.Tests/NServiceBus.TransactionalSession.Tests.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus.Testing" Version="7.4.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -49,12 +49,12 @@
             var outgoingMessages = new TransportOperations(new TransportTransportOperation(message, new UnicastAddressTag(physicalQueueAddress)));
             await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(), new ContextBag()).ConfigureAwait(false);
 
+            await synchronizedStorageSession.CompleteAsync().ConfigureAwait(false);
+
             var outboxMessage =
                 new OutboxMessage(SessionId, ConvertToOutboxOperations(pendingOperations.Operations));
             await outboxStorage.Store(outboxMessage, outboxTransaction, Context)
                 .ConfigureAwait(false);
-
-            await synchronizedStorageSession.CompleteAsync().ConfigureAwait(false);
 
             await outboxTransaction.Commit().ConfigureAwait(false);
         }


### PR DESCRIPTION
backport https://github.com/Particular/NServiceBus.TransactionalSession/pull/191 to version 1.0

including https://github.com/Particular/NServiceBus.TransactionalSession/pull/192 since that seems to be potentially required too