### PR TITLE
Complete synchronized storage session before storing outbox data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           fail-fast: false
       steps:
       - name: Checkout
-        uses: actions/checkout@v3.2.0
+        uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
       - name: Setup .NET SDK
@@ -34,11 +34,11 @@ jobs:
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages
-        if: matrix.upload-packages && runner.os == 'Windows'
-        uses: actions/upload-artifact@v3.1.1
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: NuGet packages
           path: nugets/
           retention-days: 7
       - name: Run tests
-        uses: Particular/run-tests-action@v1.4.0
+        uses: Particular/run-tests-action@v1.5.1

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/NServiceBus.TransactionalSession.AcceptanceTests.csproj
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/NServiceBus.TransactionalSession.AcceptanceTests.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_transactional_session.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_transactional_session.cs
@@ -1,0 +1,107 @@
+﻿namespace NServiceBus.TransactionalSession.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using AcceptanceTesting;
+    using Logging;
+    using NUnit.Framework;
+    using Pipeline;
+
+    public class When_using_transactional_session : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_follow_interaction_order_of_core()
+        {
+            var transactionalContext = await Scenario.Define<Context>()
+                .WithEndpoint<AnEndpoint>(s => s.When(async (_, ctx) =>
+                {
+                    using var scope = ctx.ServiceProvider.CreateScope();
+                    using var transactionalSession = scope.ServiceProvider.GetRequiredService<ITransactionalSession>();
+                    await transactionalSession.Open(new CustomTestingPersistenceOpenSessionOptions
+                    {
+                        Metadata =
+                        {
+                            {CustomTestingPersistenceOpenSessionOptions.LoggerContextName, "TransactionalSession"}
+                        }
+                    });
+
+                    await transactionalSession.SendLocal(new SomeMessage(), CancellationToken.None);
+
+                    await transactionalSession.Commit(CancellationToken.None).ConfigureAwait(false);
+                }))
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            // due to transactional session control messages also going through the incoming pipeline we run the same scenario again
+            // without the transactional session
+            var pipelineContext = await Scenario.Define<Context>()
+                .WithEndpoint<AnEndpoint>(s => s.When(async (session, ctx) =>
+                {
+                    await session.SendLocal(new SomeMessage(), CancellationToken.None);
+                }))
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            var transactionalSessionOrder = string.Join(Environment.NewLine, FilterLogs(transactionalContext, "TransactionalSession - "));
+            var pipelineOrder = string.Join(Environment.NewLine, FilterLogs(pipelineContext, "Pipeline - "));
+
+            Assert.AreEqual(pipelineOrder, transactionalSessionOrder, "The transactional session order of operation is different from the core order");
+        }
+
+        static IReadOnlyCollection<string> FilterLogs(ScenarioContext scenarioContext, string filter) =>
+            scenarioContext.Logs
+                .Where(l => l.Level == LogLevel.Info && l.LoggerName.Contains("CustomTesting"))
+                .Where(l => l.Message.StartsWith(filter))
+                // Filtering out the Get since tx session doesn't do a Get in the pipeline and potentially multiple times
+                .Where(l => !l.Message.Contains("Outbox.Get"))
+                .OrderBy(l => l.Timestamp.Ticks)
+                .Select(l => l.Message.Replace(filter, string.Empty))
+                .ToArray();
+
+        class Context : ScenarioContext, IInjectServiceProvider
+        {
+            public bool MessageReceived { get; set; }
+            public IServiceProvider ServiceProvider { get; set; }
+        }
+
+        class AnEndpoint : EndpointConfigurationBuilder
+        {
+            public AnEndpoint() =>
+                EndpointSetup<TransactionSessionWithOutboxEndpoint>(b => b.Pipeline.Register(new LoggerContextBehavior(), "Extracts the logger context header"));
+
+            class LoggerContextBehavior : Behavior<ITransportReceiveContext>
+            {
+                public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
+                {
+                    if (context.Message.Headers.TryGetValue(CustomTestingPersistenceOpenSessionOptions.LoggerContextName, out var loggerContext))
+                    {
+                        context.Extensions.Set(CustomTestingPersistenceOpenSessionOptions.LoggerContextName, loggerContext);
+                    }
+                    return next();
+                }
+            }
+
+            class MessageHandler : IHandleMessages<SomeMessage>
+            {
+                public MessageHandler(Context context) => testContext = context;
+
+                public Task Handle(SomeMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MessageReceived = true;
+
+                    return Task.CompletedTask;
+                }
+
+                readonly Context testContext;
+            }
+        }
+
+        class SomeMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingOutboxStorage.cs
+++ b/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingOutboxStorage.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.AcceptanceTesting
     using System.Threading.Tasks;
     using System.Transactions;
     using Extensibility;
+    using Logging;
     using Outbox;
     using TransactionalSession;
 
@@ -13,6 +14,9 @@ namespace NServiceBus.AcceptanceTesting
     {
         public Task<OutboxMessage> Get(string messageId, ContextBag context, CancellationToken cancellationToken = default)
         {
+            context.TryGet<string>(CustomTestingPersistenceOpenSessionOptions.LoggerContextName, out var logContext);
+            Logger.InfoFormat("{0} - Outbox.Get", logContext ?? "Pipeline");
+
             if (context.TryGet("TestOutboxStorage.GetResult", out OutboxMessage customResult))
             {
                 return Task.FromResult(customResult);
@@ -28,6 +32,9 @@ namespace NServiceBus.AcceptanceTesting
 
         public Task<IOutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default)
         {
+            context.TryGet<string>(CustomTestingPersistenceOpenSessionOptions.LoggerContextName, out var logContext);
+            Logger.InfoFormat("{0} - Outbox.BeginTransaction", logContext ?? "Pipeline");
+
             if (context.TryGet(out CustomTestingPersistenceOpenSessionOptions options) && options.UseTransactionScope)
             {
                 _ = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled);
@@ -38,6 +45,9 @@ namespace NServiceBus.AcceptanceTesting
 
         public Task Store(OutboxMessage message, IOutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default)
         {
+            context.TryGet<string>(CustomTestingPersistenceOpenSessionOptions.LoggerContextName, out var logContext);
+            Logger.InfoFormat("{0} - Outbox.Store", logContext ?? "Pipeline");
+
             var tx = (CustomTestingOutboxTransaction)transaction;
             tx.Enlist(() =>
             {
@@ -56,6 +66,9 @@ namespace NServiceBus.AcceptanceTesting
 
         public Task SetAsDispatched(string messageId, ContextBag context, CancellationToken cancellationToken = default)
         {
+            context.TryGet<string>(CustomTestingPersistenceOpenSessionOptions.LoggerContextName, out var logContext);
+            Logger.InfoFormat("{0} - Outbox.SetAsDispatched", logContext ?? "Pipeline");
+
             if (!storage.TryGetValue(messageId, out var storedMessage))
             {
                 return Task.CompletedTask;
@@ -134,5 +147,7 @@ namespace NServiceBus.AcceptanceTesting
                 }
             }
         }
+
+        static readonly ILog Logger = LogManager.GetLogger<CustomTestingOutboxStorage>();
     }
 }

--- a/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingPersistenceOpenSessionOptions.cs
+++ b/src/NServiceBus.TransactionalSession.CustomTestingPersistence/CustomTestingPersistenceOpenSessionOptions.cs
@@ -4,10 +4,16 @@
 
     public class CustomTestingPersistenceOpenSessionOptions : OpenSessionOptions
     {
-        public CustomTestingPersistenceOpenSessionOptions() => Extensions.Set(this);
+        public CustomTestingPersistenceOpenSessionOptions()
+        {
+            Extensions.Set(LoggerContextName, "TransactionalSession");
+            Extensions.Set(this);
+        }
 
         public TaskCompletionSource<bool> TransactionCommitTaskCompletionSource { get; set; }
 
         public bool UseTransactionScope { get; set; }
+
+        public const string LoggerContextName = "LoggerContext";
     }
 }

--- a/src/NServiceBus.TransactionalSession.Tests/NServiceBus.TransactionalSession.Tests.csproj
+++ b/src/NServiceBus.TransactionalSession.Tests/NServiceBus.TransactionalSession.Tests.csproj
@@ -9,10 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NServiceBus.Testing" Version="8.0.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
@@ -169,8 +169,25 @@
             Assert.AreEqual(bool.TrueString, controlMessage.Message.Headers[Headers.ControlMessageHeader]);
 
             var outboxTransaction = outboxStorage.StartedTransactions.Single();
-            Assert.IsFalse(completableSynchronizedStorageSession.Completed, "should not have completed synchronized storage session");
-            Assert.IsFalse(outboxTransaction.Commited, "should not have commited outbox operations");
+            Assert.IsFalse(outboxTransaction.Commited, "should not have committed outbox operations");
+        }
+
+        [Test]
+        public async Task Commit_should_complete_synchronized_storage_session_before_outbox_store()
+        {
+            var messageSession = new FakeMessageSession();
+            var dispatcher = new FakeDispatcher();
+            var outboxStorage = new FakeOutboxStorage { StoreCallback = (_, _, _) => throw new Exception("some error") };
+            var completableSynchronizedStorageSession = new FakeSynchronizableStorageSession();
+            using var session = new OutboxTransactionalSession(outboxStorage, completableSynchronizedStorageSession, messageSession, dispatcher, Enumerable.Empty<IOpenSessionOptionsCustomization>(), "queue address");
+
+            await session.Open(new FakeOpenSessionOptions());
+            await session.Send(new object());
+            Assert.ThrowsAsync<Exception>(async () => await session.Commit());
+
+            var outboxTransaction = outboxStorage.StartedTransactions.Single();
+            Assert.IsTrue(completableSynchronizedStorageSession.Completed, "should have completed synchronized storage session to match the receive pipeline behavior");
+            Assert.IsFalse(outboxTransaction.Commited, "should not have committed outbox operations");
         }
 
         [Test]

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -45,12 +45,12 @@
             var outgoingMessages = new TransportOperations(new TransportTransportOperation(message, new UnicastAddressTag(physicalQueueAddress)));
             await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(), cancellationToken).ConfigureAwait(false);
 
+            await synchronizedStorageSession.CompleteAsync(cancellationToken).ConfigureAwait(false);
+
             var outboxMessage =
                 new OutboxMessage(SessionId, ConvertToOutboxOperations(pendingOperations.Operations));
             await outboxStorage.Store(outboxMessage, outboxTransaction, Context, cancellationToken)
                 .ConfigureAwait(false);
-
-            await synchronizedStorageSession.CompleteAsync(cancellationToken).ConfigureAwait(false);
 
             await outboxTransaction.Commit(cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
backport https://github.com/Particular/NServiceBus.TransactionalSession/pull/191 to version 2.0

including https://github.com/Particular/NServiceBus.TransactionalSession/pull/192 since that seems to be potentially required too