### PR TITLE
Making sure the synchronized storage session gets disposed

### DIFF
--- a/src/NServiceBus.TransactionalSession.Tests/Fakes/FakeOutboxTransaction.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/Fakes/FakeOutboxTransaction.cs
@@ -6,13 +6,14 @@
 
     class FakeOutboxTransaction : IOutboxTransaction
     {
-        public bool Commited { get; private set; }
+        public bool Committed { get; private set; }
+        public bool Disposed { get; private set; }
 
-        public void Dispose() { }
+        public void Dispose() => Disposed = true;
 
         public Task Commit(CancellationToken cancellationToken = new CancellationToken())
         {
-            Commited = true;
+            Committed = true;
             return Task.CompletedTask;
         }
     }

--- a/src/NServiceBus.TransactionalSession.Tests/Fakes/FakeSynchronizableStorageSession.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/Fakes/FakeSynchronizableStorageSession.cs
@@ -16,8 +16,9 @@
         public Func<IOutboxTransaction, ContextBag, bool> TryOpenCallback { get; set; } = null;
         public Action CompleteCallback { get; set; } = null;
         public bool Completed { get; private set; }
+        public bool Disposed { get; private set; }
 
-        public void Dispose() { }
+        public void Dispose() => Disposed = true;
 
         public ValueTask<bool> TryOpen(IOutboxTransaction transaction, ContextBag context,
             CancellationToken cancellationToken = new CancellationToken())

--- a/src/NServiceBus.TransactionalSession.Tests/TransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/TransactionalSessionTests.cs
@@ -74,7 +74,7 @@
         }
 
         [Test]
-        public void Send_should_throw_exeception_when_session_not_opened()
+        public void Send_should_throw_exception_when_session_not_opened()
         {
             var messageSession = new FakeMessageSession();
             using var session = new NonOutboxTransactionalSession(new FakeSynchronizableStorageSession(), messageSession, new FakeDispatcher(), Enumerable.Empty<IOpenSessionOptionsCustomization>());
@@ -136,6 +136,20 @@
             Assert.ThrowsAsync<Exception>(async () => await session.Commit());
 
             Assert.IsEmpty(dispatcher.Dispatched, "should not have dispatched message");
+        }
+
+        [Test]
+        public async Task Dispose_should_dispose_synchronized_storage_session()
+        {
+            var synchronizedStorageSession = new FakeSynchronizableStorageSession();
+
+            var session = new NonOutboxTransactionalSession(synchronizedStorageSession, new FakeMessageSession(), new FakeDispatcher(), Enumerable.Empty<IOpenSessionOptionsCustomization>());
+            var options = new FakeOpenSessionOptions();
+            await session.Open(options);
+
+            session.Dispose();
+
+            Assert.IsTrue(synchronizedStorageSession.Disposed);
         }
     }
 }

--- a/src/NServiceBus.TransactionalSession/NonOutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/NonOutboxTransactionalSession.cs
@@ -43,5 +43,20 @@
 
             await synchronizedStorageSession.Open(null, new TransportTransaction(), Context, cancellationToken).ConfigureAwait(false);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                synchronizedStorageSession.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -46,6 +46,10 @@
             await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(), cancellationToken).ConfigureAwait(false);
 
             await synchronizedStorageSession.CompleteAsync(cancellationToken).ConfigureAwait(false);
+            // Disposing the session after complete to be compliant with the core behavior
+            // in case complete throws the synchronized storage session will get disposed by the dispose or the container
+            // disposing multiple times is safe
+            synchronizedStorageSession.Dispose();
 
             var outboxMessage =
                 new OutboxMessage(SessionId, ConvertToOutboxOperations(pendingOperations.Operations));
@@ -64,6 +68,7 @@
 
             if (disposing)
             {
+                synchronizedStorageSession.Dispose();
                 outboxTransaction?.Dispose();
             }
 


### PR DESCRIPTION
Overall only RavenDB could be problematic.

## Azure Table

Safe for disposing multiple times

https://github.com/Particular/NServiceBus.Persistence.AzureTable/blob/master/src/NServiceBus.Persistence.AzureTable/SynchronizedStorage/AzureStorageSynchronizedStorageSession.cs#L18

## SqlP

Does not safeguard against multiple disposals yet the transaction and the connection does. The dispose callback was never used in that code path and will be removed with [the outbox fix PR](https://github.com/Particular/NServiceBus.Persistence.Sql/pull/1197)

https://github.com/Particular/NServiceBus.Persistence.Sql/blob/master/src/SqlPersistence/SynchronizedStorage/StorageSession.cs#L101

## CosmosDB

Safe for disposing multiple times

https://github.com/Particular/NServiceBus.Persistence.CosmosDB/blob/master/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/CosmosSynchronizedStorageSession.cs#L54

## DynamoDB

Safe for disposing multiple times

https://github.com/Particular/NServiceBus.Persistence.DynamoDB/blob/main/src/NServiceBus.Persistence.DynamoDB/SynchronizedStorage/DynamoSynchronizedStorageSession.cs#L52

## RavenDB

Does not safeguard against multiple disposals nor clear the holder DocumentsIdsAndIndexes

https://github.com/Particular/NServiceBus.RavenDB/blob/master/src/NServiceBus.RavenDB/SessionManagement/RavenDBSynchronizedStorageSession.cs#L27C1-L32

I guess that is a bug that needs to be fixed because it is valid to dispose disposables multiple times.

## NHibernate

Does not safeguard against multiple disposals but the connection value is safe for disposing multiple times and is already disposed multiple times in certain cases

https://github.com/Particular/NServiceBus.NHibernate/blob/master/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateSynchronizedStorageSession.cs#L78

https://github.com/Particular/NServiceBus.NHibernate/blob/master/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateAmbientTransactionSynchronizedStorageSession.cs#L50
https://github.com/Particular/NServiceBus.NHibernate/blob/master/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateAmbientTransactionSynchronizedStorageSession.cs#L60
https://github.com/Particular/NServiceBus.NHibernate/blob/master/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateLazyNativeTransactionSynchronizedStorageSession.cs#L54
https://github.com/Particular/NServiceBus.NHibernate/blob/master/src/NServiceBus.NHibernate/SynchronizedStorage/NHibernateLazyNativeTransactionSynchronizedStorageSession.cs#L64
