### PR TITLE
Spike: Enable the transactional session to be used within the message handling pipeline

### DIFF
--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_transactional_session_in_the_pipeline.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_transactional_session_in_the_pipeline.cs
@@ -1,0 +1,97 @@
+﻿namespace NServiceBus.TransactionalSession.AcceptanceTests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_transactional_session_in_the_pipeline : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_work()
+        {
+            var scenarioContext = await Scenario.Define<Context>()
+                .WithEndpoint<AnEndpoint>(s => s.When(async (_, ctx) =>
+                {
+                    using var scope = ctx.ServiceProvider.CreateScope();
+                    using var transactionalSession = scope.ServiceProvider.GetRequiredService<ITransactionalSession>();
+                    await transactionalSession.Open(new CustomTestingPersistenceOpenSessionOptions());
+
+                    await transactionalSession.SendLocal(new KickOffMessage(), CancellationToken.None);
+
+                    await transactionalSession.Commit(CancellationToken.None).ConfigureAwait(false);
+                }))
+                .Done(c => c.TransactionalSessionMessageReceived && c.MessageHandlerContextMessageReceived)
+                .Run();
+
+            Assert.That(scenarioContext.TransactionalSessionMessageReceived, Is.True);
+            Assert.That(scenarioContext.MessageHandlerContextMessageReceived, Is.True);
+        }
+
+        class Context : ScenarioContext, IInjectServiceProvider
+        {
+            public bool TransactionalSessionMessageReceived { get; set; }
+            public bool MessageHandlerContextMessageReceived { get; set; }
+            public IServiceProvider ServiceProvider { get; set; }
+        }
+
+        class AnEndpoint : EndpointConfigurationBuilder
+        {
+            public AnEndpoint() =>
+                EndpointSetup<TransactionSessionDefaultServer>();
+
+            class KickOffHandler : IHandleMessages<KickOffMessage>
+            {
+                public KickOffHandler(ITransactionalSession transactionalSession) => this.transactionalSession = transactionalSession;
+
+                public async Task Handle(KickOffMessage message, IMessageHandlerContext context)
+                {
+                    await context.SendLocal(new MessageHandlerContextMessage());
+                    await transactionalSession.SendLocal(new TransactionalSessionMessage());
+                }
+
+                readonly ITransactionalSession transactionalSession;
+            }
+
+            class TransactionSessionMessageHandler : IHandleMessages<TransactionalSessionMessage>
+            {
+                public TransactionSessionMessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(TransactionalSessionMessage message, IMessageHandlerContext context)
+                {
+                    testContext.TransactionalSessionMessageReceived = true;
+                    return Task.CompletedTask;
+                }
+
+                readonly Context testContext;
+            }
+
+            class MessageHandlerContextMessageMessageHandler : IHandleMessages<MessageHandlerContextMessage>
+            {
+                public MessageHandlerContextMessageMessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(MessageHandlerContextMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MessageHandlerContextMessageReceived = true;
+                    return Task.CompletedTask;
+                }
+
+                readonly Context testContext;
+            }
+        }
+
+        class KickOffMessage : ICommand
+        {
+        }
+
+        class TransactionalSessionMessage : ICommand
+        {
+        }
+
+        class MessageHandlerContextMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_transactional_session_in_the_pipeline_with_outbox.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_transactional_session_in_the_pipeline_with_outbox.cs
@@ -1,0 +1,97 @@
+﻿namespace NServiceBus.TransactionalSession.AcceptanceTests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_using_transactional_session_in_the_pipeline_with_outbox : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_work()
+        {
+            var scenarioContext = await Scenario.Define<Context>()
+                .WithEndpoint<AnEndpoint>(s => s.When(async (_, ctx) =>
+                {
+                    using var scope = ctx.ServiceProvider.CreateScope();
+                    using var transactionalSession = scope.ServiceProvider.GetRequiredService<ITransactionalSession>();
+                    await transactionalSession.Open(new CustomTestingPersistenceOpenSessionOptions());
+
+                    await transactionalSession.SendLocal(new KickOffMessage(), CancellationToken.None);
+
+                    await transactionalSession.Commit(CancellationToken.None).ConfigureAwait(false);
+                }))
+                .Done(c => c.TransactionalSessionMessageReceived && c.MessageHandlerContextMessageReceived)
+                .Run();
+
+            Assert.That(scenarioContext.TransactionalSessionMessageReceived, Is.True);
+            Assert.That(scenarioContext.MessageHandlerContextMessageReceived, Is.True);
+        }
+
+        class Context : ScenarioContext, IInjectServiceProvider
+        {
+            public bool TransactionalSessionMessageReceived { get; set; }
+            public bool MessageHandlerContextMessageReceived { get; set; }
+            public IServiceProvider ServiceProvider { get; set; }
+        }
+
+        class AnEndpoint : EndpointConfigurationBuilder
+        {
+            public AnEndpoint() =>
+                EndpointSetup<TransactionSessionWithOutboxEndpoint>();
+
+            class KickOffHandler : IHandleMessages<KickOffMessage>
+            {
+                public KickOffHandler(ITransactionalSession transactionalSession) => this.transactionalSession = transactionalSession;
+
+                public async Task Handle(KickOffMessage message, IMessageHandlerContext context)
+                {
+                    await context.SendLocal(new MessageHandlerContextMessage());
+                    await transactionalSession.SendLocal(new TransactionalSessionMessage());
+                }
+
+                readonly ITransactionalSession transactionalSession;
+            }
+
+            class TransactionSessionMessageHandler : IHandleMessages<TransactionalSessionMessage>
+            {
+                public TransactionSessionMessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(TransactionalSessionMessage message, IMessageHandlerContext context)
+                {
+                    testContext.TransactionalSessionMessageReceived = true;
+                    return Task.CompletedTask;
+                }
+
+                readonly Context testContext;
+            }
+
+            class MessageHandlerContextMessageMessageHandler : IHandleMessages<MessageHandlerContextMessage>
+            {
+                public MessageHandlerContextMessageMessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(MessageHandlerContextMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MessageHandlerContextMessageReceived = true;
+                    return Task.CompletedTask;
+                }
+
+                readonly Context testContext;
+            }
+        }
+
+        class KickOffMessage : ICommand
+        {
+        }
+
+        class TransactionalSessionMessage : ICommand
+        {
+        }
+
+        class MessageHandlerContextMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.TransactionalSession.Tests/PipelineAwareTransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/PipelineAwareTransactionalSessionTests.cs
@@ -1,0 +1,97 @@
+﻿namespace NServiceBus.TransactionalSession.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Fakes;
+    using NUnit.Framework;
+    using Testing;
+
+    [TestFixture]
+    public class PipelineAwareTransactionalSessionTests
+    {
+        [Test]
+        public void Should_use_message_id_for_session_id()
+        {
+            var testableHandlerContext = new TestableInvokeHandlerContext { MessageId = Guid.NewGuid().ToString() };
+            using var session = new PipelineAwareTransactionalSession(new PipelineInformationHolder { WithinPipeline = true, HandlerContext = testableHandlerContext });
+
+            Assert.AreEqual(testableHandlerContext.MessageId, session.SessionId);
+        }
+
+        [Test]
+        public async Task Send_should_send_via_context()
+        {
+            var testableHandlerContext = new TestableInvokeHandlerContext();
+            using var session = new PipelineAwareTransactionalSession(new PipelineInformationHolder { WithinPipeline = true, HandlerContext = testableHandlerContext });
+
+            await session.Send(new object());
+
+            Assert.That(testableHandlerContext.SentMessages, Has.Length.EqualTo(1));
+        }
+
+        [Test]
+        public async Task Publish_should_publish_via_context()
+        {
+            var testableHandlerContext = new TestableInvokeHandlerContext();
+            using var session = new PipelineAwareTransactionalSession(new PipelineInformationHolder { WithinPipeline = true, HandlerContext = testableHandlerContext });
+
+            await session.Publish(new object());
+
+            Assert.That(testableHandlerContext.PublishedMessages, Has.Length.EqualTo(1));
+        }
+
+        [Test]
+        public void Send_should_throw_exception_when_session_not_opened()
+        {
+            using var session = new PipelineAwareTransactionalSession(new PipelineInformationHolder { WithinPipeline = true, HandlerContext = null });
+
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await session.Send(new object()));
+
+            StringAssert.Contains("This session has not been opened yet.", exception.Message);
+        }
+
+        [Test]
+        public void Publish_should_throw_exception_when_session_not_opened()
+        {
+            using var session = new PipelineAwareTransactionalSession(new PipelineInformationHolder { WithinPipeline = true, HandlerContext = null });
+
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await session.Publish(new object()));
+
+            StringAssert.Contains("This session has not been opened yet.", exception.Message);
+        }
+
+        [Test]
+        public void Should_expose_synchronized_storage_of_context()
+        {
+            var synchronizedStorageSession = new FakeSynchronizableStorageSession();
+
+            var testableHandlerContext = new TestableInvokeHandlerContext { SynchronizedStorageSession = synchronizedStorageSession };
+            var session = new PipelineAwareTransactionalSession(new PipelineInformationHolder { WithinPipeline = true, HandlerContext = testableHandlerContext });
+
+            Assert.AreSame(synchronizedStorageSession, session.SynchronizedStorageSession);
+        }
+
+        [Test]
+        public void Should_throw_exception_when_session_not_opened()
+        {
+            using var session = new PipelineAwareTransactionalSession(new PipelineInformationHolder { WithinPipeline = true, HandlerContext = null });
+
+            var exception = Assert.Throws<InvalidOperationException>(() => _ = session.SynchronizedStorageSession);
+
+            StringAssert.Contains("The session has to be opened before accessing the SynchronizedStorageSession.", exception.Message);
+        }
+
+        [Test]
+        public void Dispose_should_not_dispose_synchronized_storage_session()
+        {
+            var synchronizedStorageSession = new FakeSynchronizableStorageSession();
+
+            var testableHandlerContext = new TestableInvokeHandlerContext { SynchronizedStorageSession = synchronizedStorageSession };
+            var session = new PipelineAwareTransactionalSession(new PipelineInformationHolder { WithinPipeline = true, HandlerContext = testableHandlerContext });
+
+            session.Dispose();
+
+            Assert.IsFalse(synchronizedStorageSession.Disposed);
+        }
+    }
+}

--- a/src/NServiceBus.TransactionalSession/AttachInvokeHandlerContextBehavior.cs
+++ b/src/NServiceBus.TransactionalSession/AttachInvokeHandlerContextBehavior.cs
@@ -1,0 +1,17 @@
+namespace NServiceBus.TransactionalSession
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Pipeline;
+
+    sealed class AttachInvokeHandlerContextBehavior : IBehavior<IInvokeHandlerContext, IInvokeHandlerContext>
+    {
+        public Task Invoke(IInvokeHandlerContext context, Func<IInvokeHandlerContext, Task> next)
+        {
+            var pipelineIndicator = context.Builder.GetRequiredService<PipelineInformationHolder>();
+            pipelineIndicator.HandlerContext = context;
+            return next(context);
+        }
+    }
+}

--- a/src/NServiceBus.TransactionalSession/PipelineAwareSessionOptions.cs
+++ b/src/NServiceBus.TransactionalSession/PipelineAwareSessionOptions.cs
@@ -1,0 +1,11 @@
+namespace NServiceBus.TransactionalSession
+{
+    using Pipeline;
+
+    sealed class PipelineAwareSessionOptions : OpenSessionOptions
+    {
+        public PipelineAwareSessionOptions(IInvokeHandlerContext pipelineContext) => PipelineContext = pipelineContext;
+
+        public IInvokeHandlerContext PipelineContext { get; }
+    }
+}

--- a/src/NServiceBus.TransactionalSession/PipelineAwareTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/PipelineAwareTransactionalSession.cs
@@ -1,0 +1,135 @@
+#nullable enable
+
+namespace NServiceBus.TransactionalSession
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Persistence;
+    using Pipeline;
+
+    sealed class PipelineAwareTransactionalSession : ITransactionalSession
+    {
+        public PipelineAwareTransactionalSession(PipelineInformationHolder pipelineInformationHolder)
+            => this.pipelineInformationHolder = pipelineInformationHolder;
+
+        public ISynchronizedStorageSession SynchronizedStorageSession
+        {
+            get
+            {
+                if (!IsOpen)
+                {
+                    throw new InvalidOperationException(
+                        "The session has to be opened before accessing the SynchronizedStorageSession.");
+                }
+
+                return HandlerContext!.SynchronizedStorageSession;
+            }
+        }
+
+        public string SessionId
+        {
+            get
+            {
+                if (!IsOpen)
+                {
+                    throw new InvalidOperationException(
+                        "The session has to be opened before accessing the SessionId.");
+                }
+
+                return HandlerContext!.MessageId;
+            }
+        }
+
+        // In the invoke handler context phase the synchronized storage is ready to use
+        bool IsOpen => HandlerContext is not null;
+
+        IInvokeHandlerContext? HandlerContext => pipelineInformationHolder.HandlerContext;
+
+        public Task Open(OpenSessionOptions options, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            // TODO: Should this throw instead?
+            return Task.CompletedTask;
+        }
+
+        public Task Send(object message, SendOptions sendOptions, CancellationToken cancellationToken = default)
+        {
+            ThrowIfInvalidState();
+
+            cancellationToken.ThrowIfCancellationRequested();
+            // unfortunately there is no way to marry both tokens together
+            return HandlerContext!.Send(message, sendOptions);
+        }
+
+        public Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions, CancellationToken cancellationToken = default)
+        {
+            ThrowIfInvalidState();
+
+            cancellationToken.ThrowIfCancellationRequested();
+            // unfortunately there is no way to marry both tokens together
+            return HandlerContext!.Send(messageConstructor, sendOptions);
+        }
+
+        public Task Publish(object message, PublishOptions publishOptions, CancellationToken cancellationToken = default)
+        {
+            ThrowIfInvalidState();
+
+            cancellationToken.ThrowIfCancellationRequested();
+            // unfortunately there is no way to marry both tokens together
+            return HandlerContext!.Publish(message, publishOptions);
+        }
+
+        public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions,
+            CancellationToken cancellationToken = default)
+        {
+            ThrowIfInvalidState();
+
+            cancellationToken.ThrowIfCancellationRequested();
+            // unfortunately there is no way to marry both tokens together
+            return HandlerContext!.Publish(messageConstructor, publishOptions);
+        }
+
+        public Task Commit(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            // TODO: Should this throw instead?
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+        }
+
+        void ThrowIfInvalidState()
+        {
+            ThrowIfDisposed();
+            ThrowIfNotOpened();
+        }
+
+        void ThrowIfNotOpened()
+        {
+            if (!IsOpen)
+            {
+                throw new InvalidOperationException("This session has not been opened yet.");
+            }
+        }
+
+        void ThrowIfDisposed()
+        {
+            if (disposed)
+            {
+                throw new ObjectDisposedException(nameof(PipelineAwareTransactionalSession));
+            }
+        }
+
+        PipelineInformationHolder pipelineInformationHolder;
+        bool disposed;
+    }
+}

--- a/src/NServiceBus.TransactionalSession/PipelineIndicatorBehavior.cs
+++ b/src/NServiceBus.TransactionalSession/PipelineIndicatorBehavior.cs
@@ -1,0 +1,17 @@
+namespace NServiceBus.TransactionalSession
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Pipeline;
+
+    sealed class PipelineIndicatorBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
+    {
+        public Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
+        {
+            var pipelineIndicator = context.Builder.GetRequiredService<PipelineInformationHolder>();
+            pipelineIndicator.WithinPipeline = true;
+            return next(context);
+        }
+    }
+}

--- a/src/NServiceBus.TransactionalSession/PipelineInformationHolder.cs
+++ b/src/NServiceBus.TransactionalSession/PipelineInformationHolder.cs
@@ -1,0 +1,11 @@
+#nullable enable
+namespace NServiceBus.TransactionalSession
+{
+    using Pipeline;
+
+    sealed class PipelineInformationHolder
+    {
+        public bool WithinPipeline { get; set; }
+        public IInvokeHandlerContext? HandlerContext { get; set; }
+    }
+}

--- a/src/NServiceBus.TransactionalSession/TransactionalSessionBase.cs
+++ b/src/NServiceBus.TransactionalSession/TransactionalSessionBase.cs
@@ -104,7 +104,7 @@ namespace NServiceBus.TransactionalSession
         {
             if (disposed)
             {
-                throw new ObjectDisposedException(nameof(Dispose));
+                throw new ObjectDisposedException(GetType().Name);
             }
         }
 


### PR DESCRIPTION
Addresses https://github.com/Particular/NServiceBus.TransactionalSession/issues/65

This would allow using the transactional session as an API within the handling pipeline as well as outside the handling pipeline. With that in place the uniform session could be deprecated because the transactional session has a more powerful API by also exposing the synchronized storage consistently.

The caveats are that it is still only possible to use the session after the load handlers connector has executed inside the invoke handler stage. Additionally, this would not execute the customizations for that session because customizations are really only ever useful for sessions that are actually opened while this one is implicitly opened