### PR TITLE
Omit control message dispatch when there are no outgoing operations to be sent

### DIFF
--- a/src/NServiceBus.TransactionalSession.Tests/Fakes/FakeOutboxStorage.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/Fakes/FakeOutboxStorage.cs
@@ -10,14 +10,17 @@
     class FakeOutboxStorage : IOutboxStorage
     {
         public List<(OutboxMessage outboxMessage, IOutboxTransaction transaction, ContextBag context)> Stored { get; } = [];
+        public List<(string messageId, ContextBag context)> Dispatched { get; } = [];
         public Action<OutboxMessage, IOutboxTransaction, ContextBag> StoreCallback { get; set; } = null;
+
+        public Action<string, ContextBag> DispatchedCallback { get; set; } = null;
 
         public List<FakeOutboxTransaction> StartedTransactions { get; } = [];
 
-        public Task<OutboxMessage> Get(string messageId, ContextBag context, CancellationToken cancellationToken = new CancellationToken()) => throw new NotImplementedException();
+        public Task<OutboxMessage> Get(string messageId, ContextBag context, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
         public Task Store(OutboxMessage message, IOutboxTransaction transaction, ContextBag context,
-            CancellationToken cancellationToken = new CancellationToken())
+            CancellationToken cancellationToken = default)
         {
             Stored.Add((message, transaction, context));
             StoreCallback?.Invoke(message, transaction, context);
@@ -26,10 +29,15 @@
         }
 
         public Task SetAsDispatched(string messageId, ContextBag context,
-            CancellationToken cancellationToken = new CancellationToken()) =>
-            throw new NotImplementedException();
+            CancellationToken cancellationToken = default)
+        {
+            Dispatched.Add((messageId, context));
+            DispatchedCallback?.Invoke(messageId, context);
 
-        public Task<IOutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = new CancellationToken())
+            return Task.CompletedTask;
+        }
+
+        public Task<IOutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default)
         {
             var tx = new FakeOutboxTransaction();
             StartedTransactions.Add(tx);


### PR DESCRIPTION
Fixes #335

This PR introduces for the outbox transactional session an optimization that omits the control message dispatch when there are no outgoing messages to be sent. By default, the outbox `Store` and `SetAsDispatched` are still executed to make sure that outbox records are present. These outbox records are created by default to ensure when later the session id is exposed and served as a kind of request deduplication mechanism the records can be assumed to be there. 

A subsequent PR #349 introduces the possibility to opt-out from the creation of these records as an optimization technique for users that do not want to keep those deduplication records representing the transactional session commit tombstone.