### PR TITLE
When there are no outgoing operations do not store the outbox record

### DIFF
--- a/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
@@ -162,7 +162,7 @@
         }
 
         [Test]
-        public async Task Commit_should_not_send_control_message_when_there_are_no_outgoing_operations_but_store_and_dispatch_outbox_data()
+        public async Task Commit_should_not_send_control_message_when_there_are_no_outgoing_operations_and_not_store_the_outbox_record()
         {
             var messageSession = new FakeMessageSession();
             var dispatcher = new FakeDispatcher();
@@ -177,20 +177,13 @@
             await session.Commit();
 
             Assert.That(dispatcher.Dispatched, Is.Empty, "should not have dispatched control message");
-            Assert.That(outboxStorage.Stored, Has.Count.EqualTo(1));
-            var outboxRecord = outboxStorage.Stored.Single();
-            Assert.Multiple(() =>
-            {
-                Assert.That(outboxRecord.outboxMessage.MessageId, Is.EqualTo(session.SessionId));
-                Assert.That(outboxRecord.transaction, Is.EqualTo(outboxStorage.StartedTransactions.Single()));
-                Assert.That(outboxRecord.outboxMessage.TransportOperations, Is.Empty);
-            });
+            Assert.That(outboxStorage.Stored, Is.Empty, "should not have stored outbox record");
             Assert.Multiple(() =>
             {
                 Assert.That(synchronizedSession.Completed, Is.True);
                 Assert.That(synchronizedSession.Disposed, Is.True);
                 Assert.That(outboxStorage.StartedTransactions.Single().Committed, Is.True);
-                Assert.That(outboxStorage.Dispatched.Single().messageId, Is.EqualTo(session.SessionId));
+                Assert.That(outboxStorage.Dispatched, Is.Empty, "should not have marked it as dispatched");
             });
         }
 


### PR DESCRIPTION
Follow through of the discussion in #348 

After discussing things with @SzymonPobiega we concluded that we don't necessarily have to follow that close to the core outbox design and it is OK for the transactional session to think about the implications of the IO-operations since the transactional session has a slightly different purpose.

This PR flips the default introduced in #348 to not store and set as dispatched the outbox record as long as there is no way to provide the session ID from the outside. The reason is that without the possibility to provide and access the session ID from the outside, storing the record gives no value because it is practically impossible to correlate requests to outbox records. This means the information is not useful and the incurred IO hurts performance for no added value.

Once the session ID is settable, it is possible to re-discuss the variation as a user provided ID was used or a random ID was assigned and behave differently in those cases. Until then, it is better to not store the record (we are not loosing valuable information and eventually the information would be cleared out anyway by the outbox clearing mechanism). 