### PR TITLE
Use isolated dispatch for control message to prevent attaching to outbox's transaction scope if transport supports transaction scopes

### DIFF
--- a/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using Extensibility;
     using Fakes;
+    using NServiceBus.Transport;
     using NUnit.Framework;
 
     [TestFixture]
@@ -135,6 +136,7 @@
             var controlMessage = dispatched.outgoingMessages.UnicastTransportOperations.Single();
             Assert.Multiple(() =>
             {
+                Assert.That(controlMessage.RequiredDispatchConsistency, Is.EqualTo(DispatchConsistency.Isolated));
                 Assert.That(controlMessage.Message.MessageId, Is.EqualTo(session.SessionId));
                 Assert.That(controlMessage.Message.Headers[Headers.ControlMessageHeader], Is.EqualTo(bool.TrueString));
                 Assert.That(controlMessage.Message.Body.IsEmpty, Is.True);

--- a/src/NServiceBus.TransactionalSession.Tests/TransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/TransactionalSessionTests.cs
@@ -125,7 +125,6 @@
             var dispatchedMessage = dispatched.outgoingMessages.UnicastTransportOperations.Single();
             Assert.Multiple(() =>
             {
-                Assert.That(dispatchedMessage.RequiredDispatchConsistency, Is.EqualTo(DispatchConsistency.Isolated));
                 Assert.That(dispatchedMessage.Message.MessageId, Is.EqualTo(messageId));
                 Assert.That(dispatchedMessage.Message.Headers.ContainsKey(Headers.ControlMessageHeader), Is.False);
 

--- a/src/NServiceBus.TransactionalSession.Tests/TransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/TransactionalSessionTests.cs
@@ -6,6 +6,7 @@
     using Extensibility;
     using Fakes;
     using NUnit.Framework;
+    using Transport;
 
     [TestFixture]
     public class TransactionalSessionTests
@@ -124,6 +125,7 @@
             var dispatchedMessage = dispatched.outgoingMessages.UnicastTransportOperations.Single();
             Assert.Multiple(() =>
             {
+                Assert.That(dispatchedMessage.RequiredDispatchConsistency, Is.EqualTo(DispatchConsistency.Isolated));
                 Assert.That(dispatchedMessage.Message.MessageId, Is.EqualTo(messageId));
                 Assert.That(dispatchedMessage.Message.Headers.ContainsKey(Headers.ControlMessageHeader), Is.False);
 

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -71,8 +71,14 @@
                 }
             }
             var message = new OutgoingMessage(SessionId, headers, ReadOnlyMemory<byte>.Empty);
-            var outgoingMessages = new TransportOperations(new TransportTransportOperation(message, new UnicastAddressTag(physicalQueueAddress), null, DispatchConsistency.Isolated));
-            await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(), cancellationToken).ConfigureAwait(false);
+            var operation = new TransportTransportOperation(
+                message,
+                new UnicastAddressTag(physicalQueueAddress),
+                null,
+                DispatchConsistency.Isolated // We do not want the this dispatch to enlist in any active transaction scope like we do want for the outbox operation
+                );
+            var outgoingMessages = new TransportOperations();
+            await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(operation), cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -75,7 +75,7 @@
                 message,
                 new UnicastAddressTag(physicalQueueAddress),
                 null,
-                DispatchConsistency.Isolated // We do not want the this dispatch to enlist in any active transaction scope like we do want for the outbox operation
+                DispatchConsistency.Isolated // Avoids promoting to distributed tx by not combining transport and persistence when both share same technology
                 );
             var outgoingMessages = new TransportOperations(operation);
             await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(), cancellationToken).ConfigureAwait(false);

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -71,7 +71,7 @@
                 }
             }
             var message = new OutgoingMessage(SessionId, headers, ReadOnlyMemory<byte>.Empty);
-            var outgoingMessages = new TransportOperations(new TransportTransportOperation(message, new UnicastAddressTag(physicalQueueAddress)));
+            var outgoingMessages = new TransportOperations(new TransportTransportOperation(message, new UnicastAddressTag(physicalQueueAddress), null, DispatchConsistency.Isolated));
             await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(), cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -77,8 +77,8 @@
                 null,
                 DispatchConsistency.Isolated // We do not want the this dispatch to enlist in any active transaction scope like we do want for the outbox operation
                 );
-            var outgoingMessages = new TransportOperations();
-            await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(operation), cancellationToken).ConfigureAwait(false);
+            var outgoingMessages = new TransportOperations(operation);
+            await dispatcher.Dispatch(outgoingMessages, new TransportTransaction(), cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
Aims to solve:

- https://github.com/Particular/NServiceBus.TransactionalSession/issues/398

For correctness the control message should be dispatched immediately when requested and not be part of any transaction.

Some transports, like SQLT, attach to any contextual `TransactionScope` in the dispatcher. This creates issues when the persistence used supports `TransactionScope` mode outbox because in that case the scope is present then the transaction session is about to dispatch the control message.

These seems to be no easy way to test this change in the TransactionalSession repo so I added a test to the SQLP repo:

- https://github.com/Particular/NServiceBus.Persistence.Sql/pull/1672