### PR TITLE
Support send-only endpoints for non-outbox mode

### DIFF
--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_not_using_outbox_send_only.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_not_using_outbox_send_only.cs
@@ -37,7 +37,6 @@ public class When_not_using_outbox_send_only : NServiceBusAcceptanceTest
     class Context : ScenarioContext, IInjectServiceProvider
     {
         public bool MessageReceived { get; set; }
-        public bool CompleteMessageReceived { get; set; }
         public IServiceProvider ServiceProvider { get; set; }
     }
 

--- a/src/NServiceBus.TransactionalSession/TransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/TransactionalSession.cs
@@ -30,12 +30,12 @@ public abstract class TransactionalSession : Feature
         context.Services.AddTransient<SessionCaptureTask>();
         context.RegisterStartupTask(sp => sp.GetRequiredService<SessionCaptureTask>());
 
-        var outboxIsActive = context.Settings.IsFeatureActive(typeof(Outbox));
+        var outboxEnabled = context.Settings.IsFeatureActive(typeof(Outbox));
 
         var informationHolder = new InformationHolderToAvoidClosures
         {
-            LocalAddress = outboxIsActive ? context.LocalQueueAddress() : null,
-            IsOutboxEnabled = outboxIsActive
+            LocalAddress = outboxEnabled ? context.LocalQueueAddress() : null,
+            IsOutboxEnabled = outboxEnabled
         };
 
         context.Services.AddSingleton(informationHolder);


### PR DESCRIPTION
Supporting send only in non-outbox mode is trivial since there is no sending of control messages