### PR TITLE
Re-throw with a more specific description when detecting possibly misconfigured processor endpoints

### DIFF
--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_commits_after_control_message.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_commits_after_control_message.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.TransactionalSession.AcceptanceTests;
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using AcceptanceTesting;
@@ -44,7 +43,7 @@ public class When_outbox_commits_after_control_message : NServiceBusAcceptanceTe
             .Run();
 
         Assert.That(context.MessageReceived, Is.False);
-        Assert.That(context.Logs.ToArray().Any(m => m.Message.StartsWith("Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded")), Is.True);
+        Assert.That(context.TransactionalSessionException.Message, Does.StartWith("Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded"));
     }
 
     class Context : TransactionalSessionTestContext

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_commits_after_control_message.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_commits_after_control_message.cs
@@ -44,7 +44,7 @@ public class When_outbox_commits_after_control_message : NServiceBusAcceptanceTe
             .Run();
 
         Assert.That(context.MessageReceived, Is.False);
-        Assert.That(context.Logs.ToArray().Any(m => m.Message.StartsWith("Failure to store the outbox record. This happens if you have exceeded the maximum commit duration")), Is.True);
+        Assert.That(context.Logs.ToArray().Any(m => m.Message.StartsWith("Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded")), Is.True);
     }
 
     class Context : TransactionalSessionTestContext

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_commits_after_control_message.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_outbox_commits_after_control_message.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.TransactionalSession.AcceptanceTests;
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using AcceptanceTesting;
@@ -43,7 +44,7 @@ public class When_outbox_commits_after_control_message : NServiceBusAcceptanceTe
             .Run();
 
         Assert.That(context.MessageReceived, Is.False);
-
+        Assert.That(context.Logs.ToArray().Any(m => m.Message.StartsWith("Failure to store the outbox record. This happens if you have exceeded the maximum commit duration")), Is.True);
     }
 
     class Context : TransactionalSessionTestContext

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_send_only_endpoint_uses_processor_without_transactional_session.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_send_only_endpoint_uses_processor_without_transactional_session.cs
@@ -130,7 +130,6 @@ public class When_send_only_endpoint_uses_processor_without_transactional_sessio
             c.ConfigureTransport().TransportTransactionMode = TransportTransactionMode.ReceiveOnly;
             // Only enables the outbox and deliberately NOT enabling the transactional session
             c.EnableOutbox();
-
         });
 
         class UnblockCommitBehavior(Context testContext) : Behavior<ITransportReceiveContext>

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_send_only_endpoint_uses_processor_without_transactional_session.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_send_only_endpoint_uses_processor_without_transactional_session.cs
@@ -79,7 +79,7 @@ public class When_send_only_endpoint_uses_processor_without_transactional_sessio
             Assert.That(
                 context.Logs.ToArray().Any(m =>
                     m.Message.StartsWith(
-                        "Failure to store the outbox record. This happens if you have exceeded the maximum commit duration or if you have forgotten to enable transactional session in the processor endpoint - ")),
+                        "Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded or if the transactional session has not been enabled on the configured processor endpoint - ")),
                 Is.True);
         }
     }

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_send_only_endpoint_uses_processor_without_transactional_session.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_send_only_endpoint_uses_processor_without_transactional_session.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.TransactionalSession.AcceptanceTests;
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -77,10 +76,9 @@ public class When_send_only_endpoint_uses_processor_without_transactional_sessio
         {
             Assert.That(context.MessageReceived, Is.False);
             Assert.That(
-                context.Logs.ToArray().Any(m =>
-                    m.Message.StartsWith(
-                        "Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded or if the transactional session has not been enabled on the configured processor endpoint - ")),
-                Is.True);
+                context.TransactionalSessionException.Message,
+                Does.StartWith(
+                    "Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded or if the transactional session has not been enabled on the configured processor endpoint - "));
         }
     }
 

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_send_only_endpoint_uses_processor_without_transactional_session.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_send_only_endpoint_uses_processor_without_transactional_session.cs
@@ -1,0 +1,160 @@
+namespace NServiceBus.TransactionalSession.AcceptanceTests;
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using AcceptanceTesting;
+using AcceptanceTesting.Customization;
+using Configuration.AdvancedExtensibility;
+using NUnit.Framework;
+using Pipeline;
+
+public class When_send_only_endpoint_uses_processor_without_transactional_session : NServiceBusAcceptanceTest
+{
+    // This test verifies a specific configuration scenario: a send-only endpoint with transactional session enabled
+    // that uses a separate processor endpoint which doesn't have transactional session enabled.
+    //
+    // Under normal load conditions, forgetting to enable the transactional session in the processor endpoint
+    // might still allow transactions to complete successfully. However, under pressure or high load conditions,
+    // the missing TransactionalSessionDelayControlMessageBehavior from the Transactional Session
+    // that should have been enabled in the processor endpoint becomes critical.
+    // 
+    // When properly configured, this behavior delays processing of control messages to ensure the transactional
+    // session commit has enough time to complete. Without this behavior, the outbox might process the control
+    // message before the commit completes, creating a tombstone record that will result 
+    // in the transactional session running in the send-only endpoint to roll back the transaction.
+    //
+    // This test specifically verifies that:
+    // 1. When this configuration issue exists (send-only with separate processor missing transactional session)
+    // 2. Under pressure conditions (simulated with delays), a tombstone record is created
+    // 3. A specific, detailed warning for send-only endpoints is logged that guides developers to the root cause:
+    //    "...if you have forgotten to enable transactional session in the processor endpoint"    
+    //
+    // This helps developers identify and fix the configuration issue that
+    // may only manifest under production load conditions.
+    [Test()]
+    public async Task Should_log_specific_warning_about_missing_processor_configuration()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<SendOnlyEndpoint>(s => s.When(async (_, ctx) =>
+            {
+                using var scope = ctx.ServiceProvider.CreateScope();
+                using var transactionalSession = scope.ServiceProvider.GetRequiredService<ITransactionalSession>();
+
+                try
+                {
+                    ctx.TransactionTaskCompletionSource =
+                        new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var options = new CustomTestingPersistenceOpenSessionOptions
+                    {
+                        CommitDelayIncrement = TimeSpan.FromSeconds(1),
+                        MaximumCommitDuration = TimeSpan.FromSeconds(8),
+                        TransactionCommitTaskCompletionSource = ctx.TransactionTaskCompletionSource
+                    };
+
+                    await transactionalSession.Open(options);
+                    var sendOptions = new SendOptions();
+
+                    sendOptions.SetDestination(Conventions.EndpointNamingConvention.Invoke(typeof(AnotherEndpoint)));
+
+                    await transactionalSession.Send(new SampleMessage(), sendOptions);
+
+                    await transactionalSession.Commit(CancellationToken.None);
+                }
+                catch (Exception exception)
+                {
+                    ctx.TransactionalSessionException = exception;
+                }
+            }))
+            .WithEndpoint<AnotherEndpoint>()
+            .WithEndpoint<ProcessorEndpoint>()
+            .Done(c => c.TransactionalSessionException != null)
+            .Run();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(context.MessageReceived, Is.False);
+            Assert.That(
+                context.Logs.ToArray().Any(m =>
+                    m.Message.StartsWith(
+                        "Failure to store the outbox record. This happens if you have exceeded the maximum commit duration or if you have forgotten to enable transactional session in the processor endpoint - ")),
+                Is.True);
+        }
+    }
+
+    class Context : TransactionalSessionTestContext
+    {
+        public bool MessageReceived { get; set; }
+        public TaskCompletionSource<bool> TransactionTaskCompletionSource { get; set; }
+        public Exception TransactionalSessionException { get; set; }
+    }
+
+    class SendOnlyEndpoint : EndpointConfigurationBuilder
+    {
+        public SendOnlyEndpoint() => EndpointSetup<DefaultServer>(c =>
+        {
+            var options = new TransactionalSessionOptions
+            {
+                ProcessorEndpoint = Conventions.EndpointNamingConvention.Invoke(typeof(ProcessorEndpoint))
+            };
+
+            c.GetSettings().Get<PersistenceExtensions<CustomTestingPersistence>>().EnableTransactionalSession(options);
+
+            c.EnableOutbox();
+            c.SendOnly();
+        });
+    }
+
+    class AnotherEndpoint : EndpointConfigurationBuilder
+    {
+        public AnotherEndpoint() => EndpointSetup<DefaultServer>();
+
+        class SampleHandler(Context testContext) : IHandleMessages<SampleMessage>
+        {
+            public Task Handle(SampleMessage message, IMessageHandlerContext context)
+            {
+                testContext.MessageReceived = true;
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    class ProcessorEndpoint : EndpointConfigurationBuilder
+    {
+        public ProcessorEndpoint() => EndpointSetup<DefaultServer>((c, r) =>
+        {
+            c.Pipeline.Register(new UnblockCommitBehavior((Context)r.ScenarioContext),
+                "unblocks the transactional session commit operation");
+
+            c.ConfigureTransport().TransportTransactionMode = TransportTransactionMode.ReceiveOnly;
+            // Only enables the outbox and deliberately NOT enabling the transactional session
+            c.EnableOutbox();
+        });
+
+        class UnblockCommitBehavior(Context testContext) : Behavior<ITransportReceiveContext>
+        {
+            public override async Task Invoke(ITransportReceiveContext context, Func<Task> next)
+            {
+                if (context.Message.Headers.ContainsKey(OutboxTransactionalSession.RemainingCommitDurationHeaderName))
+                {
+                    context.Extensions.Set("TestOutboxStorage.StoreCallback", () =>
+                    {
+                        // unblock the outbox transaction from the TransactionalSession.Commit
+                        // we need to wait till the TransactionalSessionDelayControlMessageBehavior gave up on retrying and therefore
+                        // the outbox storage will store the current control message as a "tombstone".
+                        testContext.TransactionTaskCompletionSource.TrySetResult(true);
+                    });
+                }
+
+                await next();
+            }
+        }
+    }
+
+    class SampleMessage : ICommand
+    {
+    }
+}

--- a/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/OutboxTransactionalSessionTests.cs
@@ -14,7 +14,7 @@ public class OutboxTransactionalSessionTests
     [Test]
     public async Task Open_should_use_session_id_from_options()
     {
-        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), new FakeMessageSession(), new FakeDispatcher(), [], "queue address");
+        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), new FakeMessageSession(), new FakeDispatcher(), [], "queue address", isSendOnly: false);
 
         var openOptions = new FakeOpenSessionOptions();
         await session.Open(openOptions);
@@ -25,7 +25,7 @@ public class OutboxTransactionalSessionTests
     [Test]
     public async Task Open_should_throw_if_session_already_open()
     {
-        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), new FakeMessageSession(), new FakeDispatcher(), [], "queue address");
+        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), new FakeMessageSession(), new FakeDispatcher(), [], "queue address", isSendOnly: false);
 
         await session.Open(new FakeOpenSessionOptions());
 
@@ -40,7 +40,7 @@ public class OutboxTransactionalSessionTests
         var synchronizedStorageSession = new FakeSynchronizableStorageSession();
         var outboxStorage = new FakeOutboxStorage();
 
-        using var session = new OutboxTransactionalSession(outboxStorage, synchronizedStorageSession, new FakeMessageSession(), new FakeDispatcher(), [], "queue address");
+        using var session = new OutboxTransactionalSession(outboxStorage, synchronizedStorageSession, new FakeMessageSession(), new FakeDispatcher(), [], "queue address", isSendOnly: false);
 
         await session.Open(new FakeOpenSessionOptions());
 
@@ -57,7 +57,7 @@ public class OutboxTransactionalSessionTests
         var synchronizedStorageSession = new FakeSynchronizableStorageSession();
         synchronizedStorageSession.TryOpenCallback = (_, _) => false;
 
-        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), synchronizedStorageSession, new FakeMessageSession(), new FakeDispatcher(), [], "queue address");
+        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), synchronizedStorageSession, new FakeMessageSession(), new FakeDispatcher(), [], "queue address", isSendOnly: false);
 
         var exception = Assert.ThrowsAsync<Exception>(async () => await session.Open(new FakeOpenSessionOptions()));
 
@@ -68,7 +68,7 @@ public class OutboxTransactionalSessionTests
     public async Task Send_should_set_PendingOperations_collection_on_context()
     {
         var messageSession = new FakeMessageSession();
-        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), messageSession, new FakeDispatcher(), [], "queue address");
+        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), messageSession, new FakeDispatcher(), [], "queue address", isSendOnly: false);
 
         await session.Open(new FakeOpenSessionOptions());
         await session.Send(new object());
@@ -80,7 +80,7 @@ public class OutboxTransactionalSessionTests
     public async Task Publish_should_set_PendingOperations_collection_on_context()
     {
         var messageSession = new FakeMessageSession();
-        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), messageSession, new FakeDispatcher(), [], "queue address");
+        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), messageSession, new FakeDispatcher(), [], "queue address", isSendOnly: false);
 
         await session.Open(new FakeOpenSessionOptions());
         await session.Publish(new object());
@@ -92,7 +92,7 @@ public class OutboxTransactionalSessionTests
     public void Send_should_throw_exception_when_session_not_opened()
     {
         var messageSession = new FakeMessageSession();
-        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), messageSession, new FakeDispatcher(), [], "queue address");
+        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), messageSession, new FakeDispatcher(), [], "queue address", isSendOnly: false);
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await session.Send(new object()));
 
@@ -104,7 +104,7 @@ public class OutboxTransactionalSessionTests
     public void Publish_should_throw_exception_when_session_not_opened()
     {
         var messageSession = new FakeMessageSession();
-        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), messageSession, new FakeDispatcher(), [], "queue address");
+        using var session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), messageSession, new FakeDispatcher(), [], "queue address", isSendOnly: false);
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await session.Publish(new object()));
 
@@ -121,7 +121,7 @@ public class OutboxTransactionalSessionTests
         var synchronizedSession = new FakeSynchronizableStorageSession();
         string queueAddress = "queue address";
 
-        using var session = new OutboxTransactionalSession(outboxStorage, synchronizedSession, messageSession, dispatcher, [], queueAddress);
+        using var session = new OutboxTransactionalSession(outboxStorage, synchronizedSession, messageSession, dispatcher, [], queueAddress, isSendOnly: false);
 
         await session.Open(new FakeOpenSessionOptions());
         var sendOptions = new SendOptions();
@@ -172,7 +172,7 @@ public class OutboxTransactionalSessionTests
         var synchronizedSession = new FakeSynchronizableStorageSession();
         string queueAddress = "queue address";
 
-        using var session = new OutboxTransactionalSession(outboxStorage, synchronizedSession, messageSession, dispatcher, [], queueAddress);
+        using var session = new OutboxTransactionalSession(outboxStorage, synchronizedSession, messageSession, dispatcher, [], queueAddress, isSendOnly: false);
 
         await session.Open(new FakeOpenSessionOptions());
         // no outgoing operations
@@ -196,7 +196,7 @@ public class OutboxTransactionalSessionTests
         var dispatcher = new FakeDispatcher();
         var outboxStorage = new FakeOutboxStorage { StoreCallback = (_, _, _) => throw new Exception("some error") };
         var completableSynchronizedStorageSession = new FakeSynchronizableStorageSession();
-        using var session = new OutboxTransactionalSession(outboxStorage, completableSynchronizedStorageSession, messageSession, dispatcher, [], "queue address");
+        using var session = new OutboxTransactionalSession(outboxStorage, completableSynchronizedStorageSession, messageSession, dispatcher, [], "queue address", isSendOnly: false);
 
         await session.Open(new FakeOpenSessionOptions());
         await session.Send(new object());
@@ -223,7 +223,7 @@ public class OutboxTransactionalSessionTests
         var dispatcher = new FakeDispatcher();
         var outboxStorage = new FakeOutboxStorage { StoreCallback = (_, _, _) => throw new Exception("some error") };
         var completableSynchronizedStorageSession = new FakeSynchronizableStorageSession();
-        using var session = new OutboxTransactionalSession(outboxStorage, completableSynchronizedStorageSession, messageSession, dispatcher, [], "queue address");
+        using var session = new OutboxTransactionalSession(outboxStorage, completableSynchronizedStorageSession, messageSession, dispatcher, [], "queue address", isSendOnly: false);
 
         await session.Open(new FakeOpenSessionOptions());
         await session.Send(new object());
@@ -248,7 +248,7 @@ public class OutboxTransactionalSessionTests
         var messageSession = new FakeMessageSession();
         var dispatcher = new FakeDispatcher();
         var outboxStorage = new FakeOutboxStorage();
-        using var session = new OutboxTransactionalSession(outboxStorage, new FakeSynchronizableStorageSession(), messageSession, dispatcher, [], "queue address");
+        using var session = new OutboxTransactionalSession(outboxStorage, new FakeSynchronizableStorageSession(), messageSession, dispatcher, [], "queue address", isSendOnly: false);
 
         var options = new FakeOpenSessionOptions
         {
@@ -277,7 +277,7 @@ public class OutboxTransactionalSessionTests
     [Test]
     public void Operations_should_throw_when_already_disposed()
     {
-        ITransactionalSession session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), new FakeMessageSession(), new FakeDispatcher(), [], "queue address");
+        ITransactionalSession session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), new FakeMessageSession(), new FakeDispatcher(), [], "queue address", isSendOnly: false);
 
         session.Dispose();
 
@@ -292,7 +292,7 @@ public class OutboxTransactionalSessionTests
     [Test]
     public async Task Operations_should_throw_when_already_committed()
     {
-        ITransactionalSession session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), new FakeMessageSession(), new FakeDispatcher(), [], "queue address");
+        ITransactionalSession session = new OutboxTransactionalSession(new FakeOutboxStorage(), new FakeSynchronizableStorageSession(), new FakeMessageSession(), new FakeDispatcher(), [], "queue address", isSendOnly: false);
 
         await session.Open(new FakeOpenSessionOptions());
         await session.Commit();
@@ -313,7 +313,7 @@ public class OutboxTransactionalSessionTests
         var synchronizedStorageSession = new FakeSynchronizableStorageSession();
         var outboxStorage = new FakeOutboxStorage();
 
-        var session = new OutboxTransactionalSession(outboxStorage, synchronizedStorageSession, new FakeMessageSession(), new FakeDispatcher(), [], "queue address");
+        var session = new OutboxTransactionalSession(outboxStorage, synchronizedStorageSession, new FakeMessageSession(), new FakeDispatcher(), [], "queue address", isSendOnly: false);
         await session.Open(new FakeOpenSessionOptions());
 
         session.Dispose();

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -56,8 +56,8 @@ sealed class OutboxTransactionalSession(IOutboxStorage outboxStorage,
         {
             Log.Warn(
                 isSendOnly
-                    ? $"Failure to store the outbox record. This happens if you have exceeded the maximum commit duration or if you have forgotten to enable transactional session in the processor endpoint - {physicalQueueAddress}"
-                    : "Failure to store the outbox record. This happens if you have exceeded the maximum commit duration",
+                    ? $"Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded or if the transactional session has not been enabled on the configured processor endpoint - {physicalQueueAddress}"
+                    : "Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded",
                 e);
 
             throw;

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -17,7 +17,8 @@ sealed class OutboxTransactionalSession(IOutboxStorage outboxStorage,
     IMessageSession messageSession,
     IMessageDispatcher dispatcher,
     IEnumerable<IOpenSessionOptionsCustomization> customizations,
-    string physicalQueueAddress, bool isSendOnly)
+    string physicalQueueAddress,
+    bool isSendOnly)
     : TransactionalSessionBase(synchronizedStorageSession, messageSession, dispatcher, customizations)
 {
     protected override async Task CommitInternal(CancellationToken cancellationToken = default)
@@ -48,7 +49,6 @@ sealed class OutboxTransactionalSession(IOutboxStorage outboxStorage,
                 await outboxStorage.Store(outboxMessage, outboxTransaction, Context, cancellationToken)
                     .ConfigureAwait(false);
             }
-
 
             await outboxTransaction.Commit(cancellationToken).ConfigureAwait(false);
         }

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -54,11 +54,7 @@ sealed class OutboxTransactionalSession(IOutboxStorage outboxStorage,
         }
         catch (Exception e) when (e is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
         {
-            Log.Warn(
-                isSendOnly
-                    ? $"Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded or if the transactional session has not been enabled on the configured processor endpoint - {physicalQueueAddress}"
-                    : "Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded",
-                e);
+            Log.Warn($"Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded{(isSendOnly ? $" or if the transactional session has not been enabled on the configured processor endpoint - {physicalQueueAddress}" : "")}", e);
 
             throw;
         }

--- a/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/OutboxTransactionalSession.cs
@@ -10,7 +10,6 @@ using Routing;
 using Transport;
 using TransportTransportOperation = Transport.TransportOperation;
 using OutboxTransportOperation = Outbox.TransportOperation;
-using Logging;
 
 sealed class OutboxTransactionalSession(IOutboxStorage outboxStorage,
     ICompletableSynchronizedStorageSession synchronizedStorageSession,
@@ -54,9 +53,7 @@ sealed class OutboxTransactionalSession(IOutboxStorage outboxStorage,
         }
         catch (Exception e) when (e is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
         {
-            Log.Warn($"Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded{(isSendOnly ? $" or if the transactional session has not been enabled on the configured processor endpoint - {physicalQueueAddress}" : "")}", e);
-
-            throw;
+            throw new Exception($"Failed to commit the transactional session. This might happen if the maximum commit duration is exceeded{(isSendOnly ? $" or if the transactional session has not been enabled on the configured processor endpoint - {physicalQueueAddress}" : "")}", e);
         }
     }
 
@@ -171,5 +168,4 @@ sealed class OutboxTransactionalSession(IOutboxStorage outboxStorage,
 
     public const string RemainingCommitDurationHeaderName = "NServiceBus.TransactionalSession.RemainingCommitDuration";
     public const string CommitDelayIncrementHeaderName = "NServiceBus.TransactionalSession.CommitDelayIncrement";
-    static readonly ILog Log = LogManager.GetLogger<OutboxTransactionalSession>();
 }

--- a/src/NServiceBus.TransactionalSession/TransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/TransactionalSession.cs
@@ -39,8 +39,9 @@ public abstract class TransactionalSession : Feature
         context.RegisterStartupTask(sp => sp.GetRequiredService<SessionCaptureTask>());
 
         var outboxEnabled = context.Settings.IsFeatureActive(typeof(Outbox));
-        QueueAddress processorAddress = null;
         var isSendOnly = context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
+        QueueAddress processorAddress = null;
+
         if (outboxEnabled)
         {
             if (isSendOnly && string.IsNullOrWhiteSpace(transactionalSessionOptions.ProcessorEndpoint))
@@ -62,7 +63,6 @@ public abstract class TransactionalSession : Feature
         }
 
         if (!outboxEnabled && !string.IsNullOrEmpty(transactionalSessionOptions.ProcessorEndpoint))
-
         {
             throw new InvalidOperationException(
                 "A ProcessorEndpoint can only be specified for send-only endpoints with Outbox enabled");
@@ -138,7 +138,7 @@ public abstract class TransactionalSession : Feature
         public IMessageSession MessageSession { get; set; }
         public QueueAddress ControlMessageProcessorAddress { get; init; }
         public bool IsOutboxEnabled { get; init; }
-        public bool IsSendOnly { get; set; }
+        public bool IsSendOnly { get; init; }
     }
 
     class SessionCaptureTask(InformationHolderToAvoidClosures informationHolder) : FeatureStartupTask

--- a/src/NServiceBus.TransactionalSession/TransactionalSession.cs
+++ b/src/NServiceBus.TransactionalSession/TransactionalSession.cs
@@ -93,7 +93,8 @@ public abstract class TransactionalSession : Feature
                     informationHolder.MessageSession,
                     sp.GetRequiredService<IMessageDispatcher>(),
                     sp.GetServices<IOpenSessionOptionsCustomization>(),
-                    physicalProcessorQueueAddress, informationHolder.IsSendOnly);
+                    physicalProcessorQueueAddress,
+                    informationHolder.IsSendOnly);
             }
             else
             {


### PR DESCRIPTION
**Add tests that verify this specific configuration scenario:** 

Endpoint with transactional session enabled that uses a separate processor endpoint which doesn't have transactional session enabled.

**Context:**
Under normal load conditions, forgetting to enable the transactional session in the processor endpoint might still allow transactions to complete successfully. However, under pressure or high load conditions, the missing TransactionalSessionDelayControlMessageBehavior from the Transactional Session that should have been enabled in the processor endpoint becomes critical.
    
When transactional session is enabled in the processor endpoint, this behavior (in charge of the [phase 2](https://docs.particular.net/nservicebus/transactional-session/#how-it-works-phase-2) of the transactional session) delays processing of control messages to ensure the transactional session commit ([phase 1](https://docs.particular.net/nservicebus/transactional-session/#how-it-works-phase-1)) has enough time to complete. Without this behavior, the outbox might process the control message before the commit completes, resulting in a tombstone record that causes the transactional session running in the originating endpoint to roll back the transaction.
    
**These tests specifically verify that:**
    1. When this configuration issue exists (send-only or regular endpoint with a separate processor missing transactional session)
    2. Under pressure conditions (simulated with delays), a tombstone record is created
    3. A specific, detailed exception is thrown with a message that guides developers to the root cause when the endpoint is send-only:
       "...if the transactional session has not been enabled on the configured processor endpoint - "    
    4. The transaction fails, and the exception with the detailed diagnostic information is propagated to the user code


This helps developers identify and fix the configuration issue that may only manifest under production load conditions.