### PR TITLE
Add test to verify that control message is not audited

### DIFF
--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_outbox_and_audit_enabled.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_outbox_and_audit_enabled.cs
@@ -1,13 +1,12 @@
 ﻿namespace NServiceBus.TransactionalSession.AcceptanceTests;
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using AcceptanceTesting;
 using NUnit.Framework;
 using Pipeline;
-using NServiceBus.AcceptanceTesting.Customization;
+using AcceptanceTesting.Customization;
 
 public class When_using_outbox_and_audit_enabled : NServiceBusAcceptanceTest
 {
@@ -32,9 +31,9 @@ public class When_using_outbox_and_audit_enabled : NServiceBusAcceptanceTest
 
                 await transactionalSession.Open(options);
 
-                await transactionalSession.SendLocal(new SampleMessage(), CancellationToken.None);
+                await transactionalSession.SendLocal(new SampleMessage());
 
-                await transactionalSession.Commit(CancellationToken.None).ConfigureAwait(false);
+                await transactionalSession.Commit();
             }))
             .WithEndpoint<AuditSpyEndpoint>()
             .Done(c => c.TestComplete)
@@ -125,11 +124,7 @@ public class When_using_outbox_and_audit_enabled : NServiceBusAcceptanceTest
         }
     }
 
-    class SampleMessage : ICommand
-    {
-    }
+    class SampleMessage : ICommand;
 
-    class CompleteTestMessage : ICommand
-    {
-    }
+    class CompleteTestMessage : ICommand;
 }

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_outbox_and_audit_enabled.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_outbox_and_audit_enabled.cs
@@ -1,0 +1,135 @@
+﻿namespace NServiceBus.TransactionalSession.AcceptanceTests;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using AcceptanceTesting;
+using NUnit.Framework;
+using Pipeline;
+using NServiceBus.AcceptanceTesting.Customization;
+
+public class When_using_outbox_and_audit_enabled : NServiceBusAcceptanceTest
+{
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Should_not_audit_the_control_message(bool commitHappensAfterControlMessage)
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<AnEndpoint>(s => s.When(async (_, ctx) =>
+            {
+                using var scope = ctx.ServiceProvider.CreateScope();
+                using var transactionalSession = scope.ServiceProvider.GetRequiredService<ITransactionalSession>();
+
+                var options = new CustomTestingPersistenceOpenSessionOptions { TransactionCommitTaskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously) };
+
+                if (!commitHappensAfterControlMessage)
+                {
+                    options.TransactionCommitTaskCompletionSource.SetResult(true);
+                }
+
+                ctx.TxCommitTcs = options.TransactionCommitTaskCompletionSource;
+
+                await transactionalSession.Open(options);
+
+                await transactionalSession.SendLocal(new SampleMessage(), CancellationToken.None);
+
+                await transactionalSession.Commit(CancellationToken.None).ConfigureAwait(false);
+            }))
+            .WithEndpoint<AuditSpyEndpoint>()
+            .Done(c => c.TestComplete)
+            .Run();
+
+        Assert.That(context.SampleMessageAudited, Is.True);
+        Assert.That(context.ControlMessageWasAudited, Is.False);
+    }
+
+    class Context : TransactionalSessionTestContext
+    {
+        public bool SampleMessageAudited { get; set; }
+        public bool ControlMessageWasAudited { get; set; }
+        public bool TestComplete { get; set; }
+
+        public TaskCompletionSource<bool> TxCommitTcs { get; set; }
+    }
+
+    class AnEndpoint : EndpointConfigurationBuilder
+    {
+        public AnEndpoint() =>
+            EndpointSetup<TransactionSessionWithOutboxEndpoint, Context>(
+                (c, testContext) =>
+                {
+                    c.AuditProcessedMessagesTo<AuditSpyEndpoint>();
+                    c.Pipeline.Register(new DelayedOutboxTransactionCommitBehavior(testContext), "delays the outbox transaction commit");
+                });
+
+        class DelayedOutboxTransactionCommitBehavior(Context testContext) : Behavior<ITransportReceiveContext>
+        {
+            public override async Task Invoke(ITransportReceiveContext context, Func<Task> next)
+            {
+                try
+                {
+                    await next();
+                }
+                catch (ConsumeMessageException)
+                {
+                    // we don't know the order of behaviors
+                }
+
+                // unblock transaction once the receive pipeline "completed" once
+                testContext.TxCommitTcs.TrySetResult(true);
+            }
+        }
+
+        class SampleHandler : IHandleMessages<SampleMessage>
+        {
+            public Task Handle(SampleMessage message, IMessageHandlerContext context) => context.SendLocal(new CompleteTestMessage());
+        }
+
+        class CompleteTestMessageHandler : IHandleMessages<CompleteTestMessage>
+        {
+            public Task Handle(CompleteTestMessage message, IMessageHandlerContext context) => Task.CompletedTask;
+        }
+    }
+
+    class AuditSpyEndpoint : EndpointConfigurationBuilder
+    {
+        public AuditSpyEndpoint() => EndpointSetup<DefaultServer, Context>((config, context) => config.Pipeline.Register(new DetectAuditMessages(context), "Detects the message being audited"));
+
+        class DetectAuditMessages(Context testContext) : Behavior<ITransportReceiveContext>
+        {
+            public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
+            {
+                if (context.Message.Headers.ContainsKey(Headers.ControlMessageHeader))
+                {
+                    testContext.ControlMessageWasAudited = true;
+                }
+
+                if (!context.Message.Headers.TryGetValue(Headers.EnclosedMessageTypes, out var messageType))
+                {
+                    return Task.CompletedTask;
+                }
+
+                if (messageType.Contains(nameof(SampleMessage)))
+                {
+                    testContext.SampleMessageAudited = true;
+                }
+
+                if (messageType.Contains(nameof(CompleteTestMessage)))
+                {
+                    testContext.TestComplete = true;
+                }
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    class SampleMessage : ICommand
+    {
+    }
+
+    class CompleteTestMessage : ICommand
+    {
+    }
+}

--- a/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_outbox_and_audit_enabled.cs
+++ b/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_outbox_and_audit_enabled.cs
@@ -20,7 +20,11 @@ public class When_using_outbox_and_audit_enabled : NServiceBusAcceptanceTest
                 using var scope = ctx.ServiceProvider.CreateScope();
                 using var transactionalSession = scope.ServiceProvider.GetRequiredService<ITransactionalSession>();
 
-                var options = new CustomTestingPersistenceOpenSessionOptions { TransactionCommitTaskCompletionSource = ctx.TransactionCommitTaskCompletionSource };
+                var options = new CustomTestingPersistenceOpenSessionOptions
+                {
+                    TransactionCommitTaskCompletionSource = ctx.TransactionCommitTaskCompletionSource,
+                    CommitDelayIncrement = TimeSpan.FromSeconds(500)
+                };
 
                 if (!commitHappensAfterControlMessage)
                 {


### PR DESCRIPTION
Control messages are audited by default in core, but the usage pattern of the transactional session makes sure that the dispatch control message doesn't get audited.

This PR adds tests to prove that it's true for both scenarios.

## Scenario 1: Commit happens before the control message is processed

In this scenario, the core connection [will find an existing outbox record, shortcut the pipeline](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs#L29), and then dispatch the messages.

Since auditing [is happening in the physical stage of the pipeline](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs#L17), it doesn't get triggered due to the shortcut.