### PR TITLE
Ensure that CommitDelayIncrement is greater than TimeSpan.Zero

### DIFF
--- a/src/NServiceBus.TransactionalSession.Tests/OpenSessionOptionsTests.cs
+++ b/src/NServiceBus.TransactionalSession.Tests/OpenSessionOptionsTests.cs
@@ -6,6 +6,17 @@ using NUnit.Framework;
 public class OpenSessionOptionsTests
 {
     [Test]
+    public void Should_not_throw_exception_when_commit_delay_increment_is_greater_than_zero() =>
+        Assert.DoesNotThrow(() =>
+        {
+            var options = new CustomTestingPersistenceOpenSessionOptions
+            {
+                CommitDelayIncrement = TimeSpan.FromTicks(1),
+                MaximumCommitDuration = TimeSpan.FromSeconds(8)
+            };
+        });
+
+    [Test]
     [TestCase(-1)]
     [TestCase(0)]
     public void Should_throw_exception_when_commit_delay_increment_is_less_than_or_equal_to_zero(int commitDelayIncrement) =>
@@ -17,6 +28,7 @@ public class OpenSessionOptionsTests
                 MaximumCommitDuration = TimeSpan.FromSeconds(8)
             };
         });
-    class CustomTestingPersistenceOpenSessionOptions : OpenSessionOptions { }
+
+    class CustomTestingPersistenceOpenSessionOptions : OpenSessionOptions;
 }
 

--- a/src/NServiceBus.TransactionalSession/OpenSessionOptions.cs
+++ b/src/NServiceBus.TransactionalSession/OpenSessionOptions.cs
@@ -41,7 +41,12 @@ public abstract class OpenSessionOptions
     public TimeSpan CommitDelayIncrement
     {
         get;
-        set => field = (value > TimeSpan.Zero) ? value : throw new ArgumentOutOfRangeException(nameof(CommitDelayIncrement), "CommitDelayIncrement must be a non-negative TimeSpan.");
+        set
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, TimeSpan.Zero, nameof(CommitDelayIncrement));
+            field = value;
+        }
+
     } = TimeSpan.FromSeconds(2);
 
     Dictionary<string, string>? metadata;


### PR DESCRIPTION
- Fixes #530 
- Added a check to ensure that the value of `CommitDelayIncrement` is greater than `TimeSpan.Zero`.
- Added unit test to verify the behavior.
